### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/PsymoNiko/mediamtx-dashboard/security/code-scanning/3](https://github.com/PsymoNiko/mediamtx-dashboard/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/docker-build.yml` so all jobs inherit least-privilege defaults.  
For this workflow, `actions/checkout` needs `contents: read`, and pushing to GitHub Container Registry requires `packages: write`. Keep functionality unchanged by granting exactly those scopes (and no broader write access).

Best single fix:
- Edit `.github/workflows/docker-build.yml`
- Insert after the `on:` trigger block (before `jobs:`):
  - `permissions:`
  - `contents: read`
  - `packages: write`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
