### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/PsymoNiko/mediamtx-dashboard/security/code-scanning/2](https://github.com/PsymoNiko/mediamtx-dashboard/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained to the minimum needed scope.  
For this workflow, the best non-breaking fix is to set workflow-level:

- `contents: read`

This covers `actions/checkout@v4` and keeps token access read-only by default for all jobs (currently only `test`).  
Edit `.github/workflows/e2e-test.yml` by inserting the `permissions` block after the `on:` triggers and before `jobs:`.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
