### PR TITLE
Fix Docker login by proxying MediaMTX API requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,13 @@
 # MediaMTX Dashboard Environment Variables
 # Copy this file to .env and update the values
 
-# MediaMTX API URL (for the dashboard)
-NEXT_PUBLIC_MEDIAMTX_API_URL=http://localhost/v3/config
+# Server-side MediaMTX API URL used by the Next.js proxy.
+# In docker-compose.yml this is http://publisher:9997.
+MEDIAMTX_API_URL=http://localhost:9997
+
+# Browser-facing dashboard API URL. Keep the same-origin proxy unless you are
+# doing a static export and have a browser-accessible MediaMTX API URL.
+NEXT_PUBLIC_MEDIAMTX_API_URL=/api/mediamtx
 
 # MediaMTX HLS URL (for video streaming)
 NEXT_PUBLIC_MEDIAMTX_HLS_URL=http://localhost/hls

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -45,7 +45,8 @@ Create a `.env` file in the root directory to customize settings:
 \`\`\`env
 # Dashboard
 DASHBOARD_PORT=3000
-NEXT_PUBLIC_MEDIAMTX_API_URL=http://localhost:9997
+MEDIAMTX_API_URL=http://publisher:9997
+NEXT_PUBLIC_MEDIAMTX_API_URL=/api/mediamtx
 
 # MediaMTX Ports
 RTSP_PORT=8554
@@ -162,7 +163,8 @@ Create a `.env.production` file:
 
 \`\`\`env
 NODE_ENV=production
-NEXT_PUBLIC_MEDIAMTX_API_URL=https://your-domain.com/api
+MEDIAMTX_API_URL=http://mediamtx:9997
+NEXT_PUBLIC_MEDIAMTX_API_URL=/api/mediamtx
 \`\`\`
 
 ### 3. Use a reverse proxy (recommended)

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ COPY . .
 
 # Build args and envs (can be overridden at build time)
 ARG BUILD_NODE_ENV=production
-ARG NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"
+ARG NEXT_PUBLIC_MEDIAMTX_API_URL="/api/mediamtx"
 ENV NEXT_PUBLIC_MEDIAMTX_API_URL=${NEXT_PUBLIC_MEDIAMTX_API_URL}
 ARG NEXT_PUBLIC_MEDIAMTX_HLS_URL="http://localhost:80/hls"
 ENV NEXT_PUBLIC_MEDIAMTX_HLS_URL=${NEXT_PUBLIC_MEDIAMTX_HLS_URL}
@@ -116,7 +116,8 @@ FROM node:20-alpine AS runner
 WORKDIR /app
 
 # Default runtime envs (these can be overridden at container runtime with -e or --env-file)
-ENV NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"
+ENV MEDIAMTX_API_URL="http://localhost:9997"
+ENV NEXT_PUBLIC_MEDIAMTX_API_URL="/api/mediamtx"
 ENV NEXT_PUBLIC_MEDIAMTX_HLS_URL="http://localhost:80/hls"
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -33,7 +33,7 @@ COPY . .
 
 # Build args and envs (can be overridden at build time)
 ARG BUILD_NODE_ENV=production
-ARG NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"
+ARG NEXT_PUBLIC_MEDIAMTX_API_URL="/api/mediamtx"
 ENV NEXT_PUBLIC_MEDIAMTX_API_URL=${NEXT_PUBLIC_MEDIAMTX_API_URL}
 ARG NEXT_PUBLIC_MEDIAMTX_HLS_URL="http://localhost:80/hls"
 ENV NEXT_PUBLIC_MEDIAMTX_HLS_URL=${NEXT_PUBLIC_MEDIAMTX_HLS_URL}
@@ -52,7 +52,10 @@ FROM node:20-alpine AS runner
 WORKDIR /app
 
 # Default runtime envs (these can be overridden at container runtime with -e or --env-file)
-ARG NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"
+ARG NEXT_PUBLIC_MEDIAMTX_API_URL="/api/mediamtx"
+ARG MEDIAMTX_API_URL="http://localhost:9997"
+ENV MEDIAMTX_API_URL=${MEDIAMTX_API_URL}
+ENV NEXT_PUBLIC_MEDIAMTX_API_URL=${NEXT_PUBLIC_MEDIAMTX_API_URL}
 ARG NEXT_PUBLIC_MEDIAMTX_HLS_URL="http://192.168.50.11:80/hls"
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/MONITORING-QUICKSTART.md
+++ b/MONITORING-QUICKSTART.md
@@ -150,7 +150,8 @@ cp .env.example .env
 
 Edit `.env` and set your values:
 ```env
-NEXT_PUBLIC_MEDIAMTX_API_URL=http://localhost/v3/config
+MEDIAMTX_API_URL=http://localhost:9997
+NEXT_PUBLIC_MEDIAMTX_API_URL=/api/mediamtx
 NEXT_PUBLIC_MEDIAMTX_HLS_URL=http://localhost/hls
 ```
 

--- a/PNPM.md
+++ b/PNPM.md
@@ -256,7 +256,8 @@ make up
 Create \`.env\` file:
 
 \`\`\`env
-NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997
+MEDIAMTX_API_URL=http://mediamtx:9997
+NEXT_PUBLIC_MEDIAMTX_API_URL=/api/mediamtx
 NODE_ENV=production
 \`\`\`
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -11,7 +11,8 @@ Prerequisites
 
 Files
 - .env (runtime + build values)
-  - NEXT_PUBLIC_MEDIAMTX_API_URL=http://<host>:<port>/v3/config
+  - MEDIAMTX_API_URL=http://<host-or-compose-service>:9997
+  - NEXT_PUBLIC_MEDIAMTX_API_URL=/api/mediamtx
   - NEXT_PUBLIC_MEDIAMTX_HLS_URL=http://<host>:<port>/hls
   - Other runtime vars as needed
 - .env.local is ignored by builds (see .dockerignore) to prevent accidental overrides.
@@ -21,7 +22,7 @@ Build and Run
   docker compose --env-file .env up -d --build
 
 Update Config
-- Edit .env with new values for NEXT_PUBLIC_MEDIAMTX_API_URL / NEXT_PUBLIC_MEDIAMTX_HLS_URL
+- Edit .env with new values for MEDIAMTX_API_URL / NEXT_PUBLIC_MEDIAMTX_API_URL / NEXT_PUBLIC_MEDIAMTX_HLS_URL
 - Rebuild and restart:
   docker compose --env-file .env up -d --build
 
@@ -29,7 +30,7 @@ Notes
 - At runtime, env_file (./.env) still provides environment to the container, but client-side values come from build-time.
 - If you prefer plain docker build:
   docker build \
-    --build-arg NEXT_PUBLIC_MEDIAMTX_API_URL=$(grep ^NEXT_PUBLIC_MEDIAMTX_API_URL .env | cut -d= -f2-) \
+    --build-arg NEXT_PUBLIC_MEDIAMTX_API_URL=$(grep ^NEXT_PUBLIC_MEDIAMTX_API_URL .env | cut -d= -f2- || echo /api/mediamtx) \
     --build-arg NEXT_PUBLIC_MEDIAMTX_HLS_URL=$(grep ^NEXT_PUBLIC_MEDIAMTX_HLS_URL .env | cut -d= -f2-) \
     -t mediamtx-dashboard:latest .
   docker run --env-file .env -p 3000:3000 mediamtx-dashboard:latest
@@ -48,7 +49,7 @@ GitHub Pages (pnpm + Next.js)
 - Enable Pages: Repo Settings -> Pages -> Build and deployment -> Source: GitHub Actions.
 - On push to main, the workflow runs: pnpm install, next build, next export to out, then deploys.
 - For org/repo pages (not username.github.io), the site is served under /<repo>; basePath is set automatically by the workflow.
-- If you need build-time envs (e.g., NEXT_PUBLIC_MEDIAMTX_API_URL), set repo variables/secrets and export them in the workflow, e.g.:
+- If you need build-time envs for a static export, set repo variables/secrets and export them in the workflow, e.g.:
   - name: Inject envs
     run: |
       echo "NEXT_PUBLIC_MEDIAMTX_API_URL=${{ vars.NEXT_PUBLIC_MEDIAMTX_API_URL }}" >> "$GITHUB_ENV"

--- a/app/api/mediamtx/[...path]/route.ts
+++ b/app/api/mediamtx/[...path]/route.ts
@@ -1,0 +1,93 @@
+import { type NextRequest } from "next/server"
+
+export const dynamic = "force-dynamic"
+export const runtime = "nodejs"
+
+type RouteContext = {
+  params: Promise<{ path?: string[] }>
+}
+
+const DEFAULT_MEDIAMTX_API_URL = "http://localhost:9997"
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "content-encoding",
+  "content-length",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+])
+
+function getMediaMtxApiBaseUrl() {
+  const publicApiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL
+  const rawUrl =
+    process.env.MEDIAMTX_API_URL ||
+    (publicApiUrl && /^https?:\/\//i.test(publicApiUrl) ? publicApiUrl : undefined) ||
+    DEFAULT_MEDIAMTX_API_URL
+
+  return rawUrl
+    .trim()
+    .replace(/\/+$/, "")
+    .replace(/\/v3\/config$/, "")
+    .replace(/\/v3$/, "")
+}
+
+async function getPath(context: RouteContext) {
+  const params = await context.params
+  return params.path?.join("/") || ""
+}
+
+function getRequestHeaders(request: NextRequest) {
+  const headers = new Headers()
+
+  for (const name of ["accept", "authorization", "content-type"]) {
+    const value = request.headers.get(name)
+    if (value) headers.set(name, value)
+  }
+
+  return headers
+}
+
+function getResponseHeaders(upstreamHeaders: Headers) {
+  const headers = new Headers(upstreamHeaders)
+
+  for (const header of HOP_BY_HOP_HEADERS) {
+    headers.delete(header)
+  }
+
+  return headers
+}
+
+async function proxyMediaMtxRequest(request: NextRequest, context: RouteContext) {
+  const path = await getPath(context)
+  const targetUrl = new URL(`/${path}${request.nextUrl.search}`, `${getMediaMtxApiBaseUrl()}/`)
+  const init: RequestInit = {
+    method: request.method,
+    headers: getRequestHeaders(request),
+    cache: "no-store",
+  }
+
+  if (!["GET", "HEAD"].includes(request.method)) {
+    init.body = await request.arrayBuffer()
+  }
+
+  const response = await fetch(targetUrl, init)
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: getResponseHeaders(response.headers),
+  })
+}
+
+export {
+  proxyMediaMtxRequest as DELETE,
+  proxyMediaMtxRequest as GET,
+  proxyMediaMtxRequest as HEAD,
+  proxyMediaMtxRequest as PATCH,
+  proxyMediaMtxRequest as POST,
+  proxyMediaMtxRequest as PUT,
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
 import { Radio, AlertCircle } from "lucide-react"
+import { getMediaMtxApiUrl } from "@/lib/mediamtx-api-url"
 
 export default function LoginPage() {
   const router = useRouter()
@@ -25,8 +26,7 @@ export default function LoginPage() {
       const credentials = btoa(`${username}:${password}`)
 
       // Test the credentials by making a request to MediaMTX API
-      const apiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL || "http://localhost:9997"
-      const response = await fetch(`${apiUrl}/v3/config/global/get`, {
+      const response = await fetch(getMediaMtxApiUrl("/v3/config/global/get"), {
         headers: {
           Authorization: `Basic ${credentials}`,
         },

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,7 +36,8 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997
+      - MEDIAMTX_API_URL=http://mediamtx:9997
+      - NEXT_PUBLIC_MEDIAMTX_API_URL=/api/mediamtx
       - NODE_ENV=production
     depends_on:
       mediamtx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        NEXT_PUBLIC_MEDIAMTX_API_URL: ${NEXT_PUBLIC_MEDIAMTX_API_URL}
+        NEXT_PUBLIC_MEDIAMTX_API_URL: ${NEXT_PUBLIC_MEDIAMTX_API_URL:-/api/mediamtx}
         NEXT_PUBLIC_MEDIAMTX_HLS_URL: ${NEXT_PUBLIC_MEDIAMTX_HLS_URL}
     container_name: mediamtx-dashboard
     ports:
@@ -97,6 +97,9 @@ services:
     restart: unless-stopped
     env_file:
       - ./.env
+    environment:
+      MEDIAMTX_API_URL: ${MEDIAMTX_API_URL:-http://publisher:9997}
+      NEXT_PUBLIC_MEDIAMTX_API_URL: ${NEXT_PUBLIC_MEDIAMTX_API_URL:-/api/mediamtx}
     networks:
       - mediamtx_network
 

--- a/lib/mediamtx-api-url.ts
+++ b/lib/mediamtx-api-url.ts
@@ -1,0 +1,11 @@
+const DEFAULT_API_URL = "/api/mediamtx"
+
+export function getMediaMtxApiUrl(endpoint: string) {
+  const baseUrl = (process.env.NEXT_PUBLIC_MEDIAMTX_API_URL || DEFAULT_API_URL)
+    .replace(/\/+$/, "")
+    .replace(/\/v3\/config$/, "")
+    .replace(/\/v3$/, "")
+  const path = endpoint.startsWith("/") ? endpoint : `/${endpoint}`
+
+  return `${baseUrl}${path}`
+}

--- a/lib/mediamtx-api.ts
+++ b/lib/mediamtx-api.ts
@@ -1,6 +1,5 @@
 import { getAuthHeader } from "./auth"
-
-const API_URL = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL
+import { getMediaMtxApiUrl } from "./mediamtx-api-url"
 
 export interface PathConfig {
   name: string
@@ -44,7 +43,7 @@ export interface Path {
 async function fetchAPI(endpoint: string, options: RequestInit = {}) {
   const authHeader = getAuthHeader()
 
-  const response = await fetch(`${API_URL}${endpoint}`, {
+  const response = await fetch(getMediaMtxApiUrl(endpoint), {
     ...options,
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- Add a same-origin Next.js proxy at `/api/mediamtx/[...path]` so browser login and dashboard API calls do not depend on Docker-internal hostnames or MediaMTX CORS behavior.
- Route login and dashboard API requests through a shared URL helper, including normalization for older `/v3` or `/v3/config` base URLs.
- Update Docker defaults, compose files, and environment docs to use private `MEDIAMTX_API_URL` for the container-to-container MediaMTX API target while keeping `NEXT_PUBLIC_MEDIAMTX_API_URL=/api/mediamtx` browser-safe.

/claim #4

## Testing
- `npm exec --yes pnpm@9 -- install --frozen-lockfile`
- `npm exec --yes pnpm@9 -- exec tsc --noEmit --pretty false`
- `npm exec --yes pnpm@9 -- run build` compiles successfully and generates pages, then fails during `.next/standalone` trace copying on this Windows environment because pnpm/Next cannot create symlinks (`EPERM: operation not permitted, symlink ...`).
- `docker compose config` not run because Docker is not installed in this environment.