### PR TITLE
Support MediaMTX internal API alias

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ NEXT_PUBLIC_MEDIAMTX_API_URL=/api/mediamtx
 
 # Server-side MediaMTX API URL used by the dashboard proxy.
 MEDIAMTX_API_URL=http://publisher:9997
+# Optional alias for the server-side proxy upstream. If set, it takes
+# precedence over MEDIAMTX_API_URL.
+MEDIAMTX_INTERNAL_API_URL=
 
 # MediaMTX HLS URL (for video streaming)
 NEXT_PUBLIC_MEDIAMTX_HLS_URL=http://localhost/hls

--- a/app/api/mediamtx/[...path]/route.ts
+++ b/app/api/mediamtx/[...path]/route.ts
@@ -15,6 +15,7 @@ const HOP_BY_HOP_HEADERS = new Set([
 
 function normalizeUpstreamApiUrl() {
   const configuredUrl =
+    process.env.MEDIAMTX_INTERNAL_API_URL ||
     process.env.MEDIAMTX_API_URL ||
     process.env.NEXT_PUBLIC_MEDIAMTX_SERVER_API_URL ||
     process.env.NEXT_PUBLIC_MEDIAMTX_API_URL ||


### PR DESCRIPTION
## Summary
- rebase this bounty PR onto the merged Docker default-login fix on `main`
- keep a small compatibility follow-up: the same-origin MediaMTX proxy now also accepts `MEDIAMTX_INTERNAL_API_URL` as a server-side upstream alias before falling back to `MEDIAMTX_API_URL`
- document the alias in `.env.example`

## Verification
- `pnpm test`
- `pnpm exec tsc --noEmit`
- `pnpm run build`

/claim #4
