### PR TITLE
Harden MediaMTX proxy upstream URL fallback

### DIFF
--- a/app/api/mediamtx/[...path]/route.ts
+++ b/app/api/mediamtx/[...path]/route.ts
@@ -1,4 +1,4 @@
-const DEFAULT_UPSTREAM_API_URL = "http://localhost:9997"
+import { normalizeMediaMtxUpstreamApiUrl } from "@/lib/mediamtx-url.mjs"
 
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
@@ -12,16 +12,6 @@ const HOP_BY_HOP_HEADERS = new Set([
   "transfer-encoding",
   "upgrade",
 ])
-
-function normalizeUpstreamApiUrl() {
-  const configuredUrl =
-    process.env.MEDIAMTX_API_URL ||
-    process.env.NEXT_PUBLIC_MEDIAMTX_SERVER_API_URL ||
-    process.env.NEXT_PUBLIC_MEDIAMTX_API_URL ||
-    DEFAULT_UPSTREAM_API_URL
-
-  return configuredUrl.trim().replace(/\/+$/, "").replace(/\/v3\/config$/i, "").replace(/\/v3$/i, "")
-}
 
 function proxyHeaders(request: Request) {
   const headers = new Headers()
@@ -48,7 +38,7 @@ function responseHeaders(headers: Headers) {
 
 async function proxyMediaMtxRequest(request: Request, context: { params: Promise<{ path?: string[] }> }) {
   const { path = [] } = await context.params
-  const upstreamUrl = new URL(path.map(encodeURIComponent).join("/"), `${normalizeUpstreamApiUrl()}/`)
+  const upstreamUrl = new URL(path.map(encodeURIComponent).join("/"), `${normalizeMediaMtxUpstreamApiUrl()}/`)
   const incomingUrl = new URL(request.url)
   upstreamUrl.search = incomingUrl.search
 

--- a/lib/mediamtx-url.mjs
+++ b/lib/mediamtx-url.mjs
@@ -1,14 +1,29 @@
 const DEFAULT_API_BASE_URL = "/api/mediamtx"
 const DEFAULT_HLS_BASE_URL = "http://localhost:8888"
+const DEFAULT_UPSTREAM_API_URL = "http://localhost:9997"
 
 function trimTrailingSlashes(value) {
   return value.replace(/\/+$/, "")
 }
 
+function normalizeApiRoot(value) {
+  return trimTrailingSlashes(value).replace(/\/v3\/config$/i, "").replace(/\/v3$/i, "")
+}
+
+function isAbsoluteHttpUrl(value) {
+  try {
+    const url = new URL(value)
+
+    return url.protocol === "http:" || url.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
 export function normalizeMediaMtxApiBaseUrl(apiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL) {
   const configuredUrl = trimTrailingSlashes((apiUrl || DEFAULT_API_BASE_URL).trim())
 
-  return configuredUrl.replace(/\/v3\/config$/i, "").replace(/\/v3$/i, "") || DEFAULT_API_BASE_URL
+  return normalizeApiRoot(configuredUrl) || DEFAULT_API_BASE_URL
 }
 
 export function buildMediaMtxApiUrl(endpoint, apiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL) {
@@ -25,4 +40,22 @@ export function buildMediaMtxHlsUrl(pathName, hlsUrl = process.env.NEXT_PUBLIC_M
   const normalizedPathName = pathName.replace(/^\/+/, "")
 
   return `${normalizeMediaMtxHlsBaseUrl(hlsUrl)}/${normalizedPathName}/index.m3u8`
+}
+
+export function normalizeMediaMtxUpstreamApiUrl({
+  serverApiUrl = process.env.MEDIAMTX_API_URL,
+  legacyServerApiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_SERVER_API_URL,
+  publicApiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL,
+} = {}) {
+  for (const candidate of [serverApiUrl, legacyServerApiUrl, publicApiUrl, DEFAULT_UPSTREAM_API_URL]) {
+    const configuredUrl = (candidate || "").trim()
+
+    if (!configuredUrl || !isAbsoluteHttpUrl(configuredUrl)) {
+      continue
+    }
+
+    return normalizeApiRoot(configuredUrl)
+  }
+
+  return DEFAULT_UPSTREAM_API_URL
 }

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -5,6 +5,7 @@ import {
   buildMediaMtxApiUrl,
   buildMediaMtxHlsUrl,
   normalizeMediaMtxApiBaseUrl,
+  normalizeMediaMtxUpstreamApiUrl,
 } from "../lib/mediamtx-url.mjs"
 
 assert.equal(normalizeMediaMtxApiBaseUrl(undefined), "/api/mediamtx")
@@ -21,6 +22,30 @@ assert.equal(
   "http://localhost/v3/config/global/get",
 )
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
+
+assert.equal(
+  normalizeMediaMtxUpstreamApiUrl({
+    serverApiUrl: "",
+    legacyServerApiUrl: "",
+    publicApiUrl: "/api/mediamtx",
+  }),
+  "http://localhost:9997",
+)
+assert.equal(
+  normalizeMediaMtxUpstreamApiUrl({
+    serverApiUrl: "http://mediamtx:9997/v3/config",
+    publicApiUrl: "/api/mediamtx",
+  }),
+  "http://mediamtx:9997",
+)
+assert.equal(
+  normalizeMediaMtxUpstreamApiUrl({
+    serverApiUrl: "",
+    legacyServerApiUrl: "",
+    publicApiUrl: "http://localhost:9997/v3",
+  }),
+  "http://localhost:9997",
+)
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")


### PR DESCRIPTION
## Summary
- Split browser-facing MediaMTX API base URLs from server upstream API URL resolution
- Ignore relative public proxy values like `/api/mediamtx` when the API route chooses an upstream server
- Keep absolute legacy public/server URLs supported and normalize `/v3` / `/v3/config` suffixes
- Add regression coverage for the missing `MEDIAMTX_API_URL` fallback case

/claim #4

## Testing
- `node --check lib/mediamtx-url.mjs`
- `node --check scripts/test-mediamtx-url.mjs`
- `npm test`

Note: I attempted `pnpm install --frozen-lockfile` to run a full build, but the install repeatedly stalled in pnpm while linking/fetching dependencies in this environment. The focused URL regression test is dependency-free and passes locally.