### PR TITLE
fix: Docker default credentials not working

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,14 @@
+# MediaMTX Dashboard - Docker default configuration
+# This file is loaded by docker-compose.yml
+
+# Internal proxy URL (server-side, used by Next.js API routes to reach MediaMTX)
+MEDIAMTX_API_URL=http://publisher:9997
+
+# Public API URL (client-side, used by browser to reach the Next.js proxy)
+NEXT_PUBLIC_MEDIAMTX_API_URL=/api/mediamtx
+
+# HLS streaming URL (client-side)
+NEXT_PUBLIC_MEDIAMTX_HLS_URL=http://localhost/hls
+
+# WebRTC additional hosts
+MTX_WEBRTCADDITIONALHOSTS=localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,10 @@ services:
       - publisher
     restart: unless-stopped
     env_file:
-      - ./.env
+      - path: ./.env
+        required: false
+      - path: ./.env.docker
+        required: false
     environment:
       MEDIAMTX_API_URL: ${MEDIAMTX_API_URL:-http://publisher:9997}
       NEXT_PUBLIC_MEDIAMTX_API_URL: ${NEXT_PUBLIC_MEDIAMTX_API_URL:-/api/mediamtx}


### PR DESCRIPTION
## Problem

When running `docker compose up` without manually creating a `.env` file, the dashboard cannot authenticate with MediaMTX because:
1. `env_file: ./.env` fails when file does not exist
2. Without proper env vars, the proxy defaults to `localhost:9997` which does not resolve inside Docker network

## Fix

- Make `.env` optional in docker-compose (`required: false`)
- Add `.env.docker` with correct Docker networking defaults (`MEDIAMTX_API_URL=http://publisher:9997`)
- Load both `.env` and `.env.docker` as optional, with `environment:` block providing final defaults

Now `docker compose up` works out of the box with default credentials (`admin`/`adminpass`).

Fixes #4