### PR TITLE
Respect base path for MediaMTX API proxy default

### DIFF
--- a/lib/mediamtx-url.mjs
+++ b/lib/mediamtx-url.mjs
@@ -5,16 +5,34 @@ function trimTrailingSlashes(value) {
   return value.replace(/\/+$/, "")
 }
 
-export function normalizeMediaMtxApiBaseUrl(apiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL) {
-  const configuredUrl = trimTrailingSlashes((apiUrl || DEFAULT_API_BASE_URL).trim())
+function normalizeBasePath(basePath = process.env.NEXT_PUBLIC_BASE_PATH) {
+  const normalizedBasePath = trimTrailingSlashes((basePath || "").trim())
 
-  return configuredUrl.replace(/\/v3\/config$/i, "").replace(/\/v3$/i, "") || DEFAULT_API_BASE_URL
+  return normalizedBasePath ? `/${normalizedBasePath.replace(/^\/+/, "")}` : ""
 }
 
-export function buildMediaMtxApiUrl(endpoint, apiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL) {
+function defaultApiBaseUrl(basePath) {
+  return `${normalizeBasePath(basePath)}${DEFAULT_API_BASE_URL}`
+}
+
+export function normalizeMediaMtxApiBaseUrl(
+  apiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL,
+  basePath = process.env.NEXT_PUBLIC_BASE_PATH,
+) {
+  const fallbackApiUrl = defaultApiBaseUrl(basePath)
+  const configuredUrl = trimTrailingSlashes((apiUrl || fallbackApiUrl).trim())
+
+  return configuredUrl.replace(/\/v3\/config$/i, "").replace(/\/v3$/i, "") || fallbackApiUrl
+}
+
+export function buildMediaMtxApiUrl(
+  endpoint,
+  apiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL,
+  basePath = process.env.NEXT_PUBLIC_BASE_PATH,
+) {
   const normalizedEndpoint = endpoint.startsWith("/") ? endpoint : `/${endpoint}`
 
-  return `${normalizeMediaMtxApiBaseUrl(apiUrl)}${normalizedEndpoint}`
+  return `${normalizeMediaMtxApiBaseUrl(apiUrl, basePath)}${normalizedEndpoint}`
 }
 
 export function normalizeMediaMtxHlsBaseUrl(hlsUrl = process.env.NEXT_PUBLIC_MEDIAMTX_HLS_URL) {

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -8,12 +8,22 @@ import {
 } from "../lib/mediamtx-url.mjs"
 
 assert.equal(normalizeMediaMtxApiBaseUrl(undefined), "/api/mediamtx")
+assert.equal(normalizeMediaMtxApiBaseUrl(undefined, "/dashboard"), "/dashboard/api/mediamtx")
+assert.equal(normalizeMediaMtxApiBaseUrl(undefined, "dashboard/"), "/dashboard/api/mediamtx")
 assert.equal(normalizeMediaMtxApiBaseUrl("http://localhost:9997/"), "http://localhost:9997")
 assert.equal(normalizeMediaMtxApiBaseUrl("http://localhost/v3"), "http://localhost")
 assert.equal(normalizeMediaMtxApiBaseUrl("http://localhost/v3/config"), "http://localhost")
 
 assert.equal(
   buildMediaMtxApiUrl("/v3/config/global/get", "/api/mediamtx"),
+  "/api/mediamtx/v3/config/global/get",
+)
+assert.equal(
+  buildMediaMtxApiUrl("/v3/config/global/get", undefined, "/dashboard"),
+  "/dashboard/api/mediamtx/v3/config/global/get",
+)
+assert.equal(
+  buildMediaMtxApiUrl("/v3/config/global/get", "/api/mediamtx", "/dashboard"),
   "/api/mediamtx/v3/config/global/get",
 )
 assert.equal(


### PR DESCRIPTION
## Summary
- Honor `NEXT_PUBLIC_BASE_PATH` when the dashboard falls back to the default same-origin `/api/mediamtx` URL.
- Keep explicit `NEXT_PUBLIC_MEDIAMTX_API_URL` values unchanged, so existing Docker/proxy overrides continue to win.
- Add regression coverage for base-path deployments and explicit API URL precedence.

## Edge case
The app already enables Next.js `basePath` through `NEXT_PUBLIC_BASE_PATH`, but the default MediaMTX API helper still built root-relative URLs like `/api/mediamtx/v3/config/global/get`. If the dashboard is served from a subpath such as `/dashboard`, the login credential check can miss the base-path-scoped API route and fail even though the same-origin proxy exists.

## Verification
- `npm.cmd test`
- `node --check lib/mediamtx-url.mjs`
- `git diff --check`

/claim #4