### PR TITLE
Harden MediaMTX API URL normalization for full endpoint values

### DIFF
--- a/app/api/mediamtx/[...path]/route.ts
+++ b/app/api/mediamtx/[...path]/route.ts
@@ -1,3 +1,5 @@
+import { normalizeMediaMtxUpstreamApiBaseUrl } from "@/lib/mediamtx-url.mjs"
+
 const DEFAULT_UPSTREAM_API_URL = "http://localhost:9997"
 
 const HOP_BY_HOP_HEADERS = new Set([
@@ -14,13 +16,7 @@ const HOP_BY_HOP_HEADERS = new Set([
 ])
 
 function normalizeUpstreamApiUrl() {
-  const configuredUrl =
-    process.env.MEDIAMTX_API_URL ||
-    process.env.NEXT_PUBLIC_MEDIAMTX_SERVER_API_URL ||
-    process.env.NEXT_PUBLIC_MEDIAMTX_API_URL ||
-    DEFAULT_UPSTREAM_API_URL
-
-  return configuredUrl.trim().replace(/\/+$/, "").replace(/\/v3\/config$/i, "").replace(/\/v3$/i, "")
+  return normalizeMediaMtxUpstreamApiBaseUrl() || DEFAULT_UPSTREAM_API_URL
 }
 
 function proxyHeaders(request: Request) {

--- a/lib/mediamtx-url.mjs
+++ b/lib/mediamtx-url.mjs
@@ -1,20 +1,46 @@
 const DEFAULT_API_BASE_URL = "/api/mediamtx"
+const DEFAULT_UPSTREAM_API_URL = "http://localhost:9997"
 const DEFAULT_HLS_BASE_URL = "http://localhost:8888"
 
 function trimTrailingSlashes(value) {
   return value.replace(/\/+$/, "")
 }
 
-export function normalizeMediaMtxApiBaseUrl(apiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL) {
-  const configuredUrl = trimTrailingSlashes((apiUrl || DEFAULT_API_BASE_URL).trim())
+function normalizeApiSuffix(value) {
+  return trimTrailingSlashes(value).replace(/\/v3(?:\/.*)?$/i, "")
+}
 
-  return configuredUrl.replace(/\/v3\/config$/i, "").replace(/\/v3$/i, "") || DEFAULT_API_BASE_URL
+function isAbsoluteHttpUrl(value) {
+  try {
+    const url = new URL(value)
+
+    return url.protocol === "http:" || url.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+export function normalizeMediaMtxApiBaseUrl(apiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL) {
+  const configuredUrl = normalizeApiSuffix((apiUrl || DEFAULT_API_BASE_URL).trim())
+
+  return configuredUrl || DEFAULT_API_BASE_URL
 }
 
 export function buildMediaMtxApiUrl(endpoint, apiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL) {
   const normalizedEndpoint = endpoint.startsWith("/") ? endpoint : `/${endpoint}`
 
   return `${normalizeMediaMtxApiBaseUrl(apiUrl)}${normalizedEndpoint}`
+}
+
+export function normalizeMediaMtxUpstreamApiBaseUrl(
+  apiUrl = process.env.MEDIAMTX_API_URL ||
+    process.env.NEXT_PUBLIC_MEDIAMTX_SERVER_API_URL ||
+    process.env.NEXT_PUBLIC_MEDIAMTX_API_URL,
+) {
+  const configuredUrl = (apiUrl || "").trim()
+  const upstreamUrl = isAbsoluteHttpUrl(configuredUrl) ? configuredUrl : DEFAULT_UPSTREAM_API_URL
+
+  return normalizeApiSuffix(upstreamUrl)
 }
 
 export function normalizeMediaMtxHlsBaseUrl(hlsUrl = process.env.NEXT_PUBLIC_MEDIAMTX_HLS_URL) {

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -5,12 +5,15 @@ import {
   buildMediaMtxApiUrl,
   buildMediaMtxHlsUrl,
   normalizeMediaMtxApiBaseUrl,
+  normalizeMediaMtxUpstreamApiBaseUrl,
 } from "../lib/mediamtx-url.mjs"
 
 assert.equal(normalizeMediaMtxApiBaseUrl(undefined), "/api/mediamtx")
 assert.equal(normalizeMediaMtxApiBaseUrl("http://localhost:9997/"), "http://localhost:9997")
 assert.equal(normalizeMediaMtxApiBaseUrl("http://localhost/v3"), "http://localhost")
 assert.equal(normalizeMediaMtxApiBaseUrl("http://localhost/v3/config"), "http://localhost")
+assert.equal(normalizeMediaMtxApiBaseUrl("http://localhost/v3/config/global/get"), "http://localhost")
+assert.equal(normalizeMediaMtxApiBaseUrl("/api/mediamtx/v3/config/global/get"), "/api/mediamtx")
 
 assert.equal(
   buildMediaMtxApiUrl("/v3/config/global/get", "/api/mediamtx"),
@@ -20,7 +23,14 @@ assert.equal(
   buildMediaMtxApiUrl("/v3/config/global/get", "http://localhost/v3/config"),
   "http://localhost/v3/config/global/get",
 )
+assert.equal(
+  buildMediaMtxApiUrl("/v3/config/global/get", "http://localhost/v3/config/global/get"),
+  "http://localhost/v3/config/global/get",
+)
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
+
+assert.equal(normalizeMediaMtxUpstreamApiBaseUrl("http://mediamtx:9997/v3/config/global/get"), "http://mediamtx:9997")
+assert.equal(normalizeMediaMtxUpstreamApiBaseUrl("/api/mediamtx/v3/config/global/get"), "http://localhost:9997")
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")


### PR DESCRIPTION
## Summary

/claim #4

This adds a small Docker/login hardening fix for a remaining URL-normalization edge case: if a user copies a full MediaMTX API endpoint into `NEXT_PUBLIC_MEDIAMTX_API_URL`, `NEXT_PUBLIC_MEDIAMTX_SERVER_API_URL`, or `MEDIAMTX_API_URL` (for example `/v3/config/global/get` from the login error stack), the dashboard can treat that endpoint as the base URL and append `/v3/config/global/get` again.

The patch normalizes MediaMTX API bases by stripping any `/v3/...` suffix, and shares the same upstream normalization with the API proxy so server-side Docker routing behaves consistently. Relative browser-facing URLs are still not used as server upstreams; they fall back to the local MediaMTX upstream default.

This is intentionally scoped differently from the open proxy/base-path PRs: it covers copied full endpoint values and keeps the regression in the existing dependency-free URL test script.

## Verification

- `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm test`
- `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm lint`
- `COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm build`
- `git diff --check`

## Demo

This is a URL-helper/proxy regression fix rather than a visible UI change. The added test demonstrates the login URL now normalizes `http://localhost/v3/config/global/get` to `http://localhost` before appending the login check endpoint.