### PR TITLE
Make default docker compose env file optional

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -26,6 +26,8 @@ docker-compose up -d
 make up
 \`\`\`
 
+The default compose file works without a local `.env`. Create one only if you want to override the built-in Docker defaults.
+
 ### 3. Access the services
 
 - **Dashboard**: http://localhost (via nginx) or http://localhost:3000

--- a/SETUP.md
+++ b/SETUP.md
@@ -10,7 +10,7 @@ Prerequisites
 - Docker and Docker Compose v2 installed
 
 Files
-- .env (runtime + build values)
+- .env (optional override file for runtime + build values)
   - NEXT_PUBLIC_MEDIAMTX_API_URL=/api/mediamtx
   - MEDIAMTX_API_URL=http://<mediamtx-service-or-host>:9997
   - NEXT_PUBLIC_MEDIAMTX_HLS_URL=http://<host>:<port>/hls
@@ -19,15 +19,18 @@ Files
 
 Build and Run
 - Start stack and force rebuild when NEXT_PUBLIC_* changes:
+  docker compose up -d --build
+- If you want to override defaults through a local file, create `.env` and run:
   docker compose --env-file .env up -d --build
 
 Update Config
-- Edit .env with new values for NEXT_PUBLIC_MEDIAMTX_API_URL / NEXT_PUBLIC_MEDIAMTX_HLS_URL
+- Edit `.env` with new values for NEXT_PUBLIC_MEDIAMTX_API_URL / NEXT_PUBLIC_MEDIAMTX_HLS_URL
 - Rebuild and restart:
   docker compose --env-file .env up -d --build
 
 Notes
-- At runtime, env_file (./.env) still provides environment to the container, but client-side values come from build-time.
+- The default `docker-compose.yml` works without a local `.env`; runtime fallbacks are defined directly in compose.
+- If present, `./.env` is loaded as an optional override for local Docker runs, but client-side values still come from build-time.
 - If you prefer plain docker build:
   docker build \
     --build-arg NEXT_PUBLIC_MEDIAMTX_API_URL=$(grep ^NEXT_PUBLIC_MEDIAMTX_API_URL .env | cut -d= -f2-) \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,8 @@ services:
       - publisher
     restart: unless-stopped
     env_file:
-      - ./.env
+      - path: ./.env
+        required: false
     environment:
       MEDIAMTX_API_URL: ${MEDIAMTX_API_URL:-http://publisher:9997}
       NEXT_PUBLIC_MEDIAMTX_API_URL: ${NEXT_PUBLIC_MEDIAMTX_API_URL:-/api/mediamtx}

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -23,8 +23,13 @@ assert.equal(
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
+const compose = fs.readFileSync("docker-compose.yml", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
+assert.ok(compose.includes("env_file:"))
+assert.ok(compose.includes("path: ./.env"))
+assert.ok(compose.includes("required: false"))
+assert.ok(compose.includes("MEDIAMTX_API_URL: ${MEDIAMTX_API_URL:-http://publisher:9997}"))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))


### PR DESCRIPTION
## Summary
- keep `docker-compose.yml` compatible with an optional local `./.env` override instead of hard-failing when the file is absent
- preserve the existing explicit runtime fallbacks for `MEDIAMTX_API_URL` and `NEXT_PUBLIC_*` variables
- add a focused regression check for the optional compose env-file behavior
- sync the Docker setup docs so they match the optional local `.env` override behavior

## Why
Current `main` hard-requires `./.env` in the default `docker-compose.yml`, but the repository only ships `.env.example` and `.env.local`. That makes `docker compose config` / `docker compose up` fail before the dashboard can even reach the login flow.

This is separate from the current URL-normalization PRs: those improve how the dashboard reaches MediaMTX after startup, while this patch restores the default compose path so Docker users can actually start the stack without creating an extra file first.

## Demo
![PR 83 demo](https://github.com/Arthurescc/mediamtx-dashboard/releases/download/pr83-demo/mediamtx-pr83-demo.gif)

The demo shows that the repo can be missing a local `.env` file and the default `docker-compose.yml` still resolves successfully, while the focused regression check stays green.

## Checks
- `docker compose -f docker-compose.yml config`
- `node scripts/test-mediamtx-url.mjs`
- `git diff --check`

/claim #4
