### PR TITLE
fix: make docker-compose env_file optional for fresh clones

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,8 +95,6 @@ services:
     depends_on:
       - publisher
     restart: unless-stopped
-    env_file:
-      - ./.env
     environment:
       MEDIAMTX_API_URL: ${MEDIAMTX_API_URL:-http://publisher:9997}
       NEXT_PUBLIC_MEDIAMTX_API_URL: ${NEXT_PUBLIC_MEDIAMTX_API_URL:-/api/mediamtx}

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -23,8 +23,11 @@ assert.equal(
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
+const devCompose = fs.readFileSync("docker-compose.yml", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
+assert.ok(!devCompose.includes("env_file:"))
+assert.ok(devCompose.includes("MEDIAMTX_API_URL: ${MEDIAMTX_API_URL:-http://publisher:9997}"))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))


### PR DESCRIPTION
## Summary

Fixes #4

`docker-compose.yml` had `env_file: ./.env` on the `dashboard` service. When a user clones the repo and runs `docker compose up` without creating `.env` first, Docker Compose fails immediately — before the dashboard even starts, making the default-credentials login bug impossible to reproduce or test.

The `environment` block already provides safe defaults for all three variables (`MEDIAMTX_API_URL`, `NEXT_PUBLIC_MEDIAMTX_API_URL`, `NEXT_PUBLIC_MEDIAMTX_HLS_URL`), so the `env_file` directive is redundant. Users who want to override values can still create `.env` — Docker Compose picks up `.env` automatically from the project directory without an explicit `env_file` entry.

## Changes

- Remove `env_file: ./.env` from the `dashboard` service in `docker-compose.yml`
- Add regression assertion to `scripts/test-mediamtx-url.mjs` to ensure `env_file:` is not re-introduced

## Test

```bash
node scripts/test-mediamtx-url.mjs  # PASS
```
