### PR TITLE
Fix production MediaMTX healthcheck auth

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,7 +20,7 @@ services:
     networks:
       - mediamtx-network
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9997/v3/config/global/get"]
+      test: ["CMD", "wget", "--spider", "-q", "--header", "Authorization: Basic YWRtaW46YWRtaW5wYXNz", "http://localhost:9997/v3/config/global/get"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -24,7 +24,15 @@ assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://l
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const mediamtxConfig = fs.readFileSync("mediamtx.yml", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+assert.ok(mediamtxConfig.includes("authMethod: internal"))
+assert.ok(mediamtxConfig.includes("user: admin"))
+assert.ok(mediamtxConfig.includes("pass: adminpass"))
+assert.ok(
+  prodCompose.includes("Authorization: Basic YWRtaW46YWRtaW5wYXNz"),
+  "production MediaMTX healthcheck must authenticate with the default API credentials",
+)


### PR DESCRIPTION
/claim #4

## Summary
- authenticate the `docker-compose.prod.yml` MediaMTX healthcheck against the default `admin:adminpass` API credentials from `mediamtx.yml`
- keep `dashboard` from waiting forever on `depends_on: service_healthy` when production compose uses the default internal API auth configuration
- add a regression assertion to the existing URL/config test so the production healthcheck cannot silently drop auth again

## Why
`mediamtx.yml` enables `authMethod: internal` and grants API access to the default `admin` user. The production compose healthcheck was calling `/v3/config/global/get` without credentials, so the default production path could mark MediaMTX unhealthy before the dashboard had a chance to validate `admin` / `adminpass` in the UI.

This is separate from the open default compose env-file and browser URL normalization PRs; it is specific to the production compose health gate.

## Validation
- `npm test`
- `docker compose -f docker-compose.prod.yml config`
- `git diff --check`

`docker compose config` shows the MediaMTX healthcheck includes `--header 'Authorization: Basic YWRtaW46YWRtaW5wYXNz'`.

Note: Docker CLI is installed locally, but the Docker Desktop Linux engine was not running, so I could not execute a live container healthcheck in this environment.

Disclosure: AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.