### PR TITLE
Fix default MediaMTX health auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ pnpm-build: ## Build Docker image with pnpm
 pnpm-build-dev: ## Build development image with pnpm
 	docker-compose -f docker-compose.dev.yml build --no-cache
 
-pnpm-dev: export LOCALHOST=$(LOCALHOST) ## Start in development mode with hot‑reload
+pnpm-dev: export LOCALHOST=$(LOCALHOST)
+pnpm-dev: ## Start in development mode with hot‑reload
 	@echo "🚀 Running with LOCALHOST=$(LOCALHOST)"
 	docker-compose -f docker-compose.dev.yml up
 
@@ -52,6 +53,10 @@ pnpm-clean: ## Clean pnpm cache and lockfile
 # -------------------------------------------------
 .PHONY: build up down restart logs logs-dashboard logs-mediamtx clean rebuild dev \
         shell-dashboard shell-mediamtx ps health status
+
+MEDIAMTX_HEALTH_URL ?= http://localhost:9997/v3/config/global/get
+MEDIAMTX_HEALTH_USERNAME ?= admin
+MEDIAMTX_HEALTH_PASSWORD ?= adminpass
 
 build: pnpm-setup pnpm-build ## Build production images
 
@@ -99,7 +104,7 @@ ps: ## Show running containers
 
 health: ## Check service health
 	@echo "Checking services..."
-	@curl -f http://localhost:9997/v3/config/global/get 2>/dev/null && echo "✅ MediaMTX OK" || echo "❌ MediaMTX not responding"
+	@curl -f -u "$(MEDIAMTX_HEALTH_USERNAME):$(MEDIAMTX_HEALTH_PASSWORD)" "$(MEDIAMTX_HEALTH_URL)" 2>/dev/null && echo "✅ MediaMTX OK" || echo "❌ MediaMTX not responding"
 	@curl -f http://localhost:3000 2>/dev/null && echo "✅ Dashboard OK" || echo "❌ Dashboard not responding"
 
 status: ## Show detailed status

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -24,7 +24,12 @@ assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://l
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const makefile = fs.readFileSync("Makefile", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+assert.ok(makefile.includes("MEDIAMTX_HEALTH_USERNAME ?= admin"))
+assert.ok(makefile.includes("MEDIAMTX_HEALTH_PASSWORD ?= adminpass"))
+assert.ok(makefile.includes('curl -f -u "$(MEDIAMTX_HEALTH_USERNAME):$(MEDIAMTX_HEALTH_PASSWORD)" "$(MEDIAMTX_HEALTH_URL)"'))
+assert.ok(!makefile.includes("curl -f http://localhost:9997/v3/config/global/get 2>/dev/null"))


### PR DESCRIPTION
/claim #4

## Summary
- make the Makefile parseable so `make health` can run
- add configurable default MediaMTX health-check credentials that match the repo default `admin` / `adminpass` setup
- keep the default health URL configurable while preserving the current API probe target
- add a lightweight regression assertion so the health check does not silently drop default auth again

## Why
The Docker default configuration stores API access behind the `admin` user from `mediamtx.yml`, but the Makefile health target still called `/v3/config/global/get` without credentials. That can report `MediaMTX not responding` even when the default Docker credentials are valid, making the default-login path harder to verify.

This is separate from the open proxy/env-file/base-path/production-healthcheck PRs: it only hardens the local Makefile health probe used to validate the default stack.

## Validation
- `npm test`
- `make -n health`
- `git diff --check`

Disclosure: AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.