### PR TITLE
Fix MediaMTX helper service aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ logs-dashboard: ## Show logs from dashboard only
 	docker-compose logs -f dashboard
 
 logs-mediamtx: ## Show logs from MediaMTX only
-	docker-compose logs -f mediamtx
+	docker-compose logs -f publisher
 
 clean: ## Clean up everything
 	docker-compose down -v
@@ -92,7 +92,7 @@ shell-dashboard: ## Open shell in dashboard container
 	docker-compose exec dashboard sh
 
 shell-mediamtx: ## Open shell in MediaMTX container
-	docker-compose exec mediamtx sh
+	docker-compose exec publisher sh
 
 ps: ## Show running containers
 	docker-compose ps

--- a/scripts/docker-dev.sh
+++ b/scripts/docker-dev.sh
@@ -57,7 +57,7 @@ case "$1" in
     if [ "$2" = "dashboard" ]; then
       docker-compose exec dashboard sh
     elif [ "$2" = "mediamtx" ]; then
-      docker-compose exec mediamtx sh
+      docker-compose exec publisher sh
     else
       echo "Usage: $0 shell [dashboard|mediamtx]"
       exit 1

--- a/scripts/pnpm-docker.sh
+++ b/scripts/pnpm-docker.sh
@@ -52,7 +52,15 @@ case "$1" in
   
   logs)
     echo "Showing logs (Ctrl+C to exit)..."
-    docker-compose logs -f "${2:-}"
+    service="${2:-}"
+    if [ "$service" = "mediamtx" ]; then
+      service="publisher"
+    fi
+    if [ -n "$service" ]; then
+      docker-compose logs -f "$service"
+    else
+      docker-compose logs -f
+    fi
     ;;
   
   clean)
@@ -77,7 +85,7 @@ case "$1" in
     if [ "$2" = "dashboard" ]; then
       docker-compose exec dashboard sh
     elif [ "$2" = "mediamtx" ]; then
-      docker-compose exec mediamtx sh
+      docker-compose exec publisher sh
     else
       echo "Usage: $0 shell [dashboard|mediamtx]"
       exit 1

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -24,7 +24,23 @@ assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://l
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const defaultCompose = fs.readFileSync("docker-compose.yml", "utf8")
+const makefile = fs.readFileSync("Makefile", "utf8")
+const dockerDevScript = fs.readFileSync("scripts/docker-dev.sh", "utf8")
+const pnpmDockerScript = fs.readFileSync("scripts/pnpm-docker.sh", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+
+assert.ok(defaultCompose.includes("  publisher:"))
+assert.ok(makefile.includes("docker-compose logs -f publisher"))
+assert.ok(makefile.includes("docker-compose exec publisher sh"))
+assert.ok(!makefile.includes("docker-compose logs -f mediamtx"))
+assert.ok(!makefile.includes("docker-compose exec mediamtx sh"))
+assert.ok(dockerDevScript.includes("docker-compose exec publisher sh"))
+assert.ok(!dockerDevScript.includes("docker-compose exec mediamtx sh"))
+assert.ok(pnpmDockerScript.includes('if [ "$service" = "mediamtx" ]; then'))
+assert.ok(pnpmDockerScript.includes('if [ -n "$service" ]; then'))
+assert.ok(pnpmDockerScript.includes("docker-compose exec publisher sh"))
+assert.ok(!pnpmDockerScript.includes("docker-compose exec mediamtx sh"))


### PR DESCRIPTION
## Summary
- retarget Makefile MediaMTX log/shell helpers to the default compose service name, `publisher`
- keep the `mediamtx` user-facing alias in the Docker helper scripts while mapping it to `publisher`
- add regression assertions so future helper changes stay aligned with the default compose file

## Verification
- npm test

## Demo
![Demo recording](https://raw.githubusercontent.com/xXGoziXx/mediamtx-dashboard/codex/demo-assets-pr88/docs/demo/mediamtx-dashboard-pr88-demo.gif)

The demo shows the default `publisher` service, the updated helper targets, the preserved `mediamtx` alias, and the passing regression test.

/claim #4

AI-assisted with Codex.
