### PR TITLE
Wait for MediaMTX API health in default compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,12 @@ services:
     stdin_open: true
     networks:
       - mediamtx_network
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "--header", "Authorization: Basic YWRtaW46YWRtaW5wYXNz", "http://localhost:9997/v3/config/global/get"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
 
   dashboard:
     image: psymoniko/mediamtx-dashboard:latest
@@ -93,7 +99,8 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - publisher
+      publisher:
+        condition: service_healthy
     restart: unless-stopped
     env_file:
       - ./.env

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -23,8 +23,12 @@ assert.equal(
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
+const defaultCompose = fs.readFileSync("docker-compose.yml", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
+assert.match(defaultCompose, /publisher:\r?\n[\s\S]*?healthcheck:/)
+assert.ok(defaultCompose.includes("Authorization: Basic YWRtaW46YWRtaW5wYXNz"))
+assert.match(defaultCompose, /depends_on:\r?\n\s+publisher:\r?\n\s+condition: service_healthy/)
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))


### PR DESCRIPTION
/claim #4

## Summary
- add an authenticated healthcheck to the default `publisher` MediaMTX service in `docker-compose.yml`
- make the dashboard wait for `publisher` to become `service_healthy` before starting
- add regression assertions so the default compose path keeps the authenticated API health gate

## Why this helps default credentials
The default compose path could start `dashboard` as soon as the `publisher` container was created, even if the MediaMTX API was not ready to answer authenticated `/v3/config/global/get` requests yet. That leaves a short but real window where `admin` / `adminpass` can fail during startup even though the credentials are correct.

## Validation
- `npm test`
- `git diff --check`
- `docker compose -f docker-compose.yml config` with a temporary `.env` copied from `.env.example`

## Demo
Config validation confirms the default compose file now parses with the new health gate:

```text
docker compose config passed with temporary .env
```

AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.