### PR TITLE
Fix Debian Dockerfile dependency install

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -5,14 +5,19 @@
 FROM node:20-slim AS deps
 WORKDIR /app
 
+ARG PNPM_VERSION=9
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
 # Install openssl for Prisma (if needed)
-RUN apt-get update && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y openssl && rm -rf /var/lib/apt/lists/* && \
+    npm install -g pnpm@"${PNPM_VERSION}" --no-audit --no-fund
 
 # Copy package files
-COPY package.json package-lock.json* ./
+COPY package.json pnpm-lock.yaml* ./
 
 # Install dependencies
-RUN npm ci
+RUN pnpm install --frozen-lockfile --reporter=silent
 
 # Stage 2: Builder
 FROM node:20-slim AS builder

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -23,8 +23,12 @@ assert.equal(
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
+const debianDockerfile = fs.readFileSync("Dockerfile.debian", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
+assert.ok(debianDockerfile.includes("pnpm-lock.yaml"))
+assert.ok(debianDockerfile.includes("pnpm install --frozen-lockfile"))
+assert.ok(!debianDockerfile.includes("npm ci"))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))


### PR DESCRIPTION
/claim #4

## Summary
- update `Dockerfile.debian` to install dependencies with pnpm instead of `npm ci`
- copy `pnpm-lock.yaml` into the Debian dependency stage so the prod Docker path uses the lockfile that is actually in the repo
- add a regression check so this Dockerfile does not drift back to a missing npm lockfile

## Why
`docker-compose.prod.yml` builds the dashboard with `Dockerfile.debian`. That Dockerfile currently copies `package-lock.json*` and runs `npm ci`, but the repo only has `pnpm-lock.yaml`. On a clean checkout, the production compose build can fail before the dashboard container starts, which blocks the default MediaMTX login path entirely.

## Validation
- `npm test`
- `git diff --check`

I could not run a full Docker build in this environment because Docker is not installed here.
