### PR TITLE
Fix dev compose pull policy for fresh clones

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,7 +7,7 @@ x-restart-policy: &restart_policy
   restart: unless-stopped
 
 x-pull-policy: &pull_policy
-  pull_policy: never          # Use local images only (adjust or remove as needed)
+  pull_policy: missing        # Pull images on fresh clones, reuse local images when present.
 
 x-depends_on-healthy: &depends_on_healthy
   condition: service_healthy

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -24,7 +24,10 @@ assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://l
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const devCompose = fs.readFileSync("docker-compose.dev.yml", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+assert.ok(!devCompose.includes("pull_policy: never"))
+assert.ok(devCompose.includes("pull_policy: missing"))


### PR DESCRIPTION
/claim #4

## Summary

Fixes a remaining dev Docker Compose startup blocker for fresh clones.

`docker-compose.dev.yml` currently sets the shared service pull policy to `never`. On a machine without the referenced local images already present, the documented dev-compose path can fail before the dashboard reaches the default credential flow. Using `pull_policy: missing` preserves local-image reuse when images exist, while allowing Compose to pull the configured images on first run.

## Why this matters

This is separate from the env-file, URL-normalization, healthcheck, helper-alias, and production Dockerfile PRs already opened for #4. It addresses the case where the dev stack cannot start on a clean machine because Compose refuses to pull missing images.

## Changes

- Change the dev compose shared pull policy from `never` to `missing`.
- Add regression assertions to the existing config/url test so this does not silently regress.

## Validation

- `npm.cmd test`
- `node scripts/test-mediamtx-url.mjs`
- `git diff --check`

## Demo

![MediaMTX dev compose demo](https://github.com/alexgduarte/mediamtx-dashboard/releases/download/mediamtx-pr92-demo-20260513/mediamtx-pr92-demo.gif)

The demo shows the branch and commit, the two-file diff, `npm.cmd test`, and `git diff --check`.
