### PR TITLE
Fix alternative Dockerfile MediaMTX defaults

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -24,6 +24,10 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+ARG NEXT_PUBLIC_MEDIAMTX_API_URL="/api/mediamtx"
+ARG NEXT_PUBLIC_MEDIAMTX_HLS_URL="http://localhost:80/hls"
+ENV NEXT_PUBLIC_MEDIAMTX_API_URL=${NEXT_PUBLIC_MEDIAMTX_API_URL}
+ENV NEXT_PUBLIC_MEDIAMTX_HLS_URL=${NEXT_PUBLIC_MEDIAMTX_HLS_URL}
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
 
@@ -35,6 +39,9 @@ WORKDIR /app
 
 ENV NODE_ENV=development
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_PUBLIC_MEDIAMTX_API_URL="/api/mediamtx"
+ENV MEDIAMTX_API_URL="http://publisher:9997"
+ENV NEXT_PUBLIC_MEDIAMTX_HLS_URL="http://localhost:80/hls"
 
 # Non-root user
 RUN addgroup --system --gid 1001 nodejs && \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -24,6 +24,10 @@ COPY . .
 
 # Disable telemetry during build
 ENV NEXT_TELEMETRY_DISABLED=1
+ARG NEXT_PUBLIC_MEDIAMTX_API_URL="/api/mediamtx"
+ARG NEXT_PUBLIC_MEDIAMTX_HLS_URL="http://localhost:80/hls"
+ENV NEXT_PUBLIC_MEDIAMTX_API_URL=${NEXT_PUBLIC_MEDIAMTX_API_URL}
+ENV NEXT_PUBLIC_MEDIAMTX_HLS_URL=${NEXT_PUBLIC_MEDIAMTX_HLS_URL}
 
 # Build application
 RUN npm run build
@@ -34,6 +38,9 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_PUBLIC_MEDIAMTX_API_URL="/api/mediamtx"
+ENV MEDIAMTX_API_URL="http://publisher:9997"
+ENV NEXT_PUBLIC_MEDIAMTX_HLS_URL="http://localhost:80/hls"
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -23,8 +23,15 @@ assert.equal(
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
+const devDockerfile = fs.readFileSync("Dockerfile.dev", "utf8")
+const simpleDockerfile = fs.readFileSync("Dockerfile.simple", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+
+for (const alternativeDockerfile of [devDockerfile, simpleDockerfile]) {
+  assert.ok(alternativeDockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="/api/mediamtx"'))
+  assert.ok(alternativeDockerfile.includes('MEDIAMTX_API_URL="http://publisher:9997"'))
+}


### PR DESCRIPTION
## Summary
- add build-time `NEXT_PUBLIC_MEDIAMTX_*` defaults to `Dockerfile.dev` and `Dockerfile.simple`
- add a runtime `MEDIAMTX_API_URL=http://publisher:9997` default to those alternative images so the same-origin `/api/mediamtx` proxy does not fall back to container-local `localhost:9997`
- extend the existing MediaMTX URL regression script to cover the advertised alternative Dockerfiles

## Why
The main `Dockerfile` already defaults the server-side MediaMTX upstream to the default compose service (`publisher:9997`). The advertised alternative images did not, so a dashboard built from `Dockerfile.dev` or `Dockerfile.simple` could still fail the default `admin/adminpass` login path unless users supplied `MEDIAMTX_API_URL` manually.

## Validation
- `npm test`
- `git diff --check`

Docker is not available in this environment, so I could not run a container smoke test.

AI-assisted with OpenAI Codex; diff reviewed before submission.

/claim #4