### PR TITLE
Fix Makefile Docker helper entrypoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help: ## Show this help message
 	@echo 'Usage: make [target] [VARIABLE=value]'
 	@echo ''
 	@echo 'Available targets:'
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-25s %s\n", $1, $2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-25s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 # -------------------------------------------------
 # pnpm‑specific commands
@@ -39,12 +39,12 @@ pnpm-build: ## Build Docker image with pnpm
 pnpm-build-dev: ## Build development image with pnpm
 	docker-compose -f docker-compose.dev.yml build --no-cache
 
-pnpm-dev: export LOCALHOST=$(LOCALHOST) ## Start in development mode with hot‑reload
+pnpm-dev: ## Start in development mode with hot‑reload
 	@echo "🚀 Running with LOCALHOST=$(LOCALHOST)"
-	docker-compose -f docker-compose.dev.yml up
+	LOCALHOST=$(LOCALHOST) docker-compose -f docker-compose.dev.yml up
 
-pnpm-clean: ## Clean pnpm cache and lockfile
-	rm -rf node_modules .next pnpm-lock.yaml
+pnpm-clean: ## Clean local pnpm build artifacts
+	rm -rf node_modules .next
 	pnpm store prune || true
 
 # -------------------------------------------------

--- a/scripts/pnpm-docker.sh
+++ b/scripts/pnpm-docker.sh
@@ -59,7 +59,7 @@ case "$1" in
     echo "Cleaning up..."
     docker-compose down -v
     docker-compose -f docker-compose.dev.yml down -v 2>/dev/null || true
-    rm -rf node_modules .next pnpm-lock.yaml
+    rm -rf node_modules .next
     docker system prune -f
     echo "✅ Cleanup complete!"
     ;;

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -24,7 +24,13 @@ assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://l
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const makefile = fs.readFileSync("Makefile", "utf8")
+const pnpmDocker = fs.readFileSync("scripts/pnpm-docker.sh", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+assert.ok(!makefile.includes("pnpm-dev: export LOCALHOST=$(LOCALHOST)"))
+assert.ok(makefile.includes('printf "  %-25s %s\\n", $$1, $$2'))
+assert.ok(!makefile.includes("rm -rf node_modules .next pnpm-lock.yaml"))
+assert.ok(!pnpmDocker.includes("rm -rf node_modules .next pnpm-lock.yaml"))


### PR DESCRIPTION
Related to #4

/claim #4

## Summary
- Fix the Makefile so `make` can parse Docker helper targets again.
- Keep `LOCALHOST` scoped to the `pnpm-dev` compose command without breaking help-comment parsing.
- Stop the clean helpers from deleting the committed `pnpm-lock.yaml` before rebuilds.
- Add regression assertions to the existing smoke test.

## Why
On current `main`, `make -n pnpm-clean` fails before any Docker/login path can run:

```text
Makefile:44: *** commands commence before first target.  Stop.
```

After fixing the Makefile syntax, the rebuild path also should not remove the repository lockfile immediately before `pnpm` Docker builds. Keeping the lockfile preserves the default Docker helper flow before users test the `admin` / `adminpass` login.

## Validation
- `npm test`
- `make help`
- `make -n pnpm-dev`
- `make -n rebuild`
- `bash -n scripts/pnpm-docker.sh`
- `git diff --check`

## Demo
`make help` now lists the helper targets, and `make -n rebuild` reaches the Docker build/start commands while preserving `pnpm-lock.yaml`:

```text
rm -rf node_modules .next
pnpm store prune || true
...
docker-compose build --no-cache
docker-compose up -d
```

AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.