### PR TITLE
Support Docker Compose v2 in quick-start helpers

### DIFF
--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -4,11 +4,30 @@ echo "🚀 MediaMTX Quick Start"
 echo "======================="
 echo ""
 
+compose_cmd=()
+
+resolve_compose() {
+    if docker compose version > /dev/null 2>&1; then
+        compose_cmd=(docker compose)
+    elif command -v docker-compose > /dev/null 2>&1; then
+        compose_cmd=(docker-compose)
+    else
+        echo "❌ Docker Compose is not installed. Install Docker Compose v2 or the legacy docker-compose binary."
+        exit 1
+    fi
+}
+
+compose() {
+    "${compose_cmd[@]}" "$@"
+}
+
 # Check if Docker is running
 if ! docker info > /dev/null 2>&1; then
     echo "❌ Docker is not running. Please start Docker first."
     exit 1
 fi
+
+resolve_compose
 
 echo "Choose a start method:"
 echo ""
@@ -22,7 +41,7 @@ case $choice in
     1)
         echo ""
         echo "Starting MediaMTX server only..."
-        docker-compose -f docker-compose.local.yml up -d
+        compose -f docker-compose.local.yml up -d
         echo ""
         echo "✅ MediaMTX is running!"
         echo ""
@@ -40,10 +59,10 @@ case $choice in
         ./scripts/setup-docker.sh
         echo ""
         echo "Building Docker images (this may take a few minutes)..."
-        docker-compose -f docker-compose.yml build --no-cache
+        compose -f docker-compose.yml build --no-cache
         echo ""
         echo "Starting services..."
-        docker-compose -f docker-compose.yml up -d
+        compose -f docker-compose.yml up -d
         echo ""
         echo "✅ Services are starting!"
         echo ""
@@ -55,7 +74,7 @@ case $choice in
     3)
         echo ""
         echo "Starting services with existing images..."
-        docker-compose -f docker-compose.yml up -d
+        compose -f docker-compose.yml up -d
         echo ""
         echo "✅ Services started!"
         echo ""

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -24,7 +24,13 @@ assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://l
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const quickStart = fs.readFileSync("scripts/quick-start.sh", "utf8")
+const troubleshoot = fs.readFileSync("scripts/troubleshoot.sh", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+assert.ok(quickStart.includes("docker compose version"))
+assert.ok(!quickStart.includes("docker-compose -f "))
+assert.ok(troubleshoot.includes("docker compose version"))
+assert.ok(!troubleshoot.includes("docker-compose build --build-arg DOCKERFILE=Dockerfile.debian"))

--- a/scripts/troubleshoot.sh
+++ b/scripts/troubleshoot.sh
@@ -4,6 +4,12 @@ echo "🔍 MediaMTX Docker Troubleshooting"
 echo "=================================="
 echo ""
 
+compose_cmd=()
+
+compose_command() {
+    printf "%s " "${compose_cmd[@]}"
+}
+
 # Check Docker
 echo "1. Checking Docker installation..."
 if command -v docker &> /dev/null; then
@@ -16,10 +22,15 @@ fi
 # Check Docker Compose
 echo ""
 echo "2. Checking Docker Compose..."
-if command -v docker-compose &> /dev/null; then
+if docker compose version &> /dev/null; then
+    compose_cmd=(docker compose)
+    echo "   ✅ Docker Compose is installed: $(docker compose version)"
+elif command -v docker-compose &> /dev/null; then
+    compose_cmd=(docker-compose)
     echo "   ✅ Docker Compose is installed: $(docker-compose --version)"
 else
     echo "   ❌ Docker Compose is not installed"
+    echo "   Install Docker Compose v2 or the legacy docker-compose binary"
     exit 1
 fi
 
@@ -30,7 +41,7 @@ if ping -c 1 dl-cdn.alpinelinux.org &> /dev/null; then
     echo "   ✅ Can reach Alpine package servers"
 else
     echo "   ⚠️  Cannot reach Alpine servers (will use Debian image)"
-    echo "   Run: docker-compose build --build-arg DOCKERFILE=Dockerfile.debian"
+    echo "   Run: $(compose_command)-f docker-compose.prod.yml build dashboard"
 fi
 
 # Check ports
@@ -66,10 +77,8 @@ else
         docker rmi mediamtx-test:debian &> /dev/null
         echo ""
         echo "   💡 Recommendation: Use Dockerfile.debian"
-        echo "   Edit docker-compose.yml and change:"
-        echo "   dockerfile: Dockerfile"
-        echo "   to:"
-        echo "   dockerfile: Dockerfile.debian"
+        echo "   Run the Debian compose stack:"
+        echo "   $(compose_command)-f docker-compose.prod.yml up -d --build"
     else
         echo "   ❌ Debian build also failed"
     fi


### PR DESCRIPTION
## Summary
- resolve either `docker compose` v2 or legacy `docker-compose` in the quick-start helper before starting Docker services
- make the troubleshooting helper accept Compose v2 and replace the no-op Debian build-arg suggestion with the existing Debian compose stack
- add regression assertions so the helpers keep supporting Compose v2 and do not regress to the old build-arg guidance

## Why
The docs require Docker Compose v2, but the quick-start/troubleshooting scripts only called the legacy `docker-compose` binary. On modern Docker installs where only `docker compose` is available, these helpers can exit before users ever start the Docker stack and test the default `admin` / `adminpass` login flow.

## Validation
- `npm test`
- `bash -n scripts/quick-start.sh`
- `bash -n scripts/troubleshoot.sh`
- `git diff --check`

## Demo
The regression test now reads both helper scripts and verifies they probe `docker compose version`, avoid raw `docker-compose -f` quick-start calls, and no longer suggest `docker-compose build --build-arg DOCKERFILE=Dockerfile.debian`.

/claim #4

AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.