### PR TITLE
Support Docker Compose v2 in manager scripts

### DIFF
--- a/scripts/docker-dev.sh
+++ b/scripts/docker-dev.sh
@@ -7,10 +7,29 @@ set -e
 echo "🐳 MediaMTX Dashboard - Docker Development Helper"
 echo ""
 
+compose_cmd=()
+
+resolve_compose() {
+  if docker compose version > /dev/null 2>&1; then
+    compose_cmd=(docker compose)
+  elif command -v docker-compose > /dev/null 2>&1; then
+    compose_cmd=(docker-compose)
+  else
+    echo "❌ Docker Compose is not installed. Install Docker Compose v2 or the legacy docker-compose binary."
+    exit 1
+  fi
+}
+
+compose() {
+  "${compose_cmd[@]}" "$@"
+}
+
+resolve_compose
+
 case "$1" in
   start)
     echo "Starting services..."
-    docker-compose up -d
+    compose up -d
     echo "✅ Services started!"
     echo "Dashboard: http://localhost:3000"
     echo "MediaMTX API: http://localhost:9997"
@@ -18,46 +37,46 @@ case "$1" in
   
   stop)
     echo "Stopping services..."
-    docker-compose down
+    compose down
     echo "✅ Services stopped!"
     ;;
   
   restart)
     echo "Restarting services..."
-    docker-compose restart
+    compose restart
     echo "✅ Services restarted!"
     ;;
   
   logs)
     echo "Showing logs (Ctrl+C to exit)..."
-    docker-compose logs -f
+    compose logs -f
     ;;
   
   rebuild)
     echo "Rebuilding services..."
-    docker-compose down
-    docker-compose build --no-cache
-    docker-compose up -d
+    compose down
+    compose build --no-cache
+    compose up -d
     echo "✅ Services rebuilt and started!"
     ;;
   
   clean)
     echo "Cleaning up..."
-    docker-compose down -v
+    compose down -v
     docker system prune -f
     echo "✅ Cleanup complete!"
     ;;
   
   status)
     echo "Service status:"
-    docker-compose ps
+    compose ps
     ;;
   
   shell)
     if [ "$2" = "dashboard" ]; then
-      docker-compose exec dashboard sh
+      compose exec dashboard sh
     elif [ "$2" = "mediamtx" ]; then
-      docker-compose exec mediamtx sh
+      compose exec mediamtx sh
     else
       echo "Usage: $0 shell [dashboard|mediamtx]"
       exit 1

--- a/scripts/pnpm-docker.sh
+++ b/scripts/pnpm-docker.sh
@@ -7,6 +7,25 @@ set -e
 echo "🚀 MediaMTX Dashboard - pnpm Docker Manager"
 echo ""
 
+compose_cmd=()
+
+resolve_compose() {
+  if docker compose version > /dev/null 2>&1; then
+    compose_cmd=(docker compose)
+  elif command -v docker-compose > /dev/null 2>&1; then
+    compose_cmd=(docker-compose)
+  else
+    echo "❌ Docker Compose is not installed. Install Docker Compose v2 or the legacy docker-compose binary."
+    exit 1
+  fi
+}
+
+compose() {
+  "${compose_cmd[@]}" "$@"
+}
+
+resolve_compose
+
 case "$1" in
   setup)
     echo "Setting up pnpm environment..."
@@ -16,17 +35,17 @@ case "$1" in
   
   build)
     echo "Building with pnpm..."
-    docker-compose build --no-cache
+    compose build --no-cache
     ;;
   
   build-dev)
     echo "Building development image with pnpm..."
-    docker-compose -f docker-compose.dev.yml build --no-cache
+    compose -f docker-compose.dev.yml build --no-cache
     ;;
   
   start)
     echo "Starting services..."
-    docker-compose up -d
+    compose up -d
     echo "✅ Services started!"
     echo "Dashboard: http://localhost:3000"
     echo "MediaMTX API: http://localhost:9997"
@@ -34,31 +53,31 @@ case "$1" in
   
   dev)
     echo "Starting in development mode with hot-reload..."
-    docker-compose -f docker-compose.dev.yml up
+    compose -f docker-compose.dev.yml up
     ;;
   
   stop)
     echo "Stopping services..."
-    docker-compose down
-    docker-compose -f docker-compose.dev.yml down 2>/dev/null || true
+    compose down
+    compose -f docker-compose.dev.yml down 2>/dev/null || true
     echo "✅ Services stopped!"
     ;;
   
   restart)
     echo "Restarting services..."
-    docker-compose restart
+    compose restart
     echo "✅ Services restarted!"
     ;;
   
   logs)
     echo "Showing logs (Ctrl+C to exit)..."
-    docker-compose logs -f "${2:-}"
+    compose logs -f "${2:-}"
     ;;
   
   clean)
     echo "Cleaning up..."
-    docker-compose down -v
-    docker-compose -f docker-compose.dev.yml down -v 2>/dev/null || true
+    compose down -v
+    compose -f docker-compose.dev.yml down -v 2>/dev/null || true
     rm -rf node_modules .next pnpm-lock.yaml
     docker system prune -f
     echo "✅ Cleanup complete!"
@@ -75,9 +94,9 @@ case "$1" in
   
   shell)
     if [ "$2" = "dashboard" ]; then
-      docker-compose exec dashboard sh
+      compose exec dashboard sh
     elif [ "$2" = "mediamtx" ]; then
-      docker-compose exec mediamtx sh
+      compose exec mediamtx sh
     else
       echo "Usage: $0 shell [dashboard|mediamtx]"
       exit 1
@@ -92,7 +111,7 @@ case "$1" in
   
   status)
     echo "Service status:"
-    docker-compose ps
+    compose ps
     echo ""
     echo "Docker images:"
     docker images | grep mediamtx

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -24,7 +24,18 @@ assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://l
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const dockerDevScript = fs.readFileSync("scripts/docker-dev.sh", "utf8")
+const pnpmDockerScript = fs.readFileSync("scripts/pnpm-docker.sh", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+
+for (const [scriptName, script] of [
+  ["scripts/docker-dev.sh", dockerDevScript],
+  ["scripts/pnpm-docker.sh", pnpmDockerScript],
+]) {
+  assert.ok(script.includes("docker compose version"), `${scriptName} should probe Docker Compose v2`)
+  assert.ok(script.includes("compose_cmd=(docker compose)"), `${scriptName} should prefer Docker Compose v2`)
+  assert.ok(!/^\s*docker-compose\s+(up|down|restart|logs|build|ps|exec|-f)\b/m.test(script))
+}


### PR DESCRIPTION
## Summary
- resolve Docker Compose as either `docker compose` v2 or legacy `docker-compose` in `scripts/docker-dev.sh`
- apply the same Compose command wrapper to `scripts/pnpm-docker.sh`
- add regression assertions so both manager scripts keep preferring Compose v2 and stop directly invoking legacy `docker-compose`

## Why
The repo docs require Docker Compose v2, but two advertised helper scripts still call the legacy `docker-compose` binary directly. On modern Docker installs where only `docker compose` is available, those scripts can fail before users start MediaMTX/dashboard and test the default `admin` / `adminpass` Docker login path.

This is separate from #96, which only covers the quick-start and troubleshooting scripts.

## Validation
- `npm test`
- `bash -n scripts/docker-dev.sh`
- `bash -n scripts/pnpm-docker.sh`
- `git diff --check`

## Demo
The regression test now reads both Docker manager scripts and verifies they probe `docker compose version`, configure `compose_cmd=(docker compose)` as the preferred command, and do not directly invoke legacy `docker-compose` in the script bodies.

/claim #4

AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.