### PR TITLE
Harden MediaMTX proxy upstream URL normalization

### DIFF
--- a/app/api/mediamtx/[...path]/route.ts
+++ b/app/api/mediamtx/[...path]/route.ts
@@ -1,4 +1,4 @@
-const DEFAULT_UPSTREAM_API_URL = "http://localhost:9997"
+import { normalizeMediaMtxServerApiBaseUrl } from "@/lib/mediamtx-url.mjs"
 
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
@@ -12,16 +12,6 @@ const HOP_BY_HOP_HEADERS = new Set([
   "transfer-encoding",
   "upgrade",
 ])
-
-function normalizeUpstreamApiUrl() {
-  const configuredUrl =
-    process.env.MEDIAMTX_API_URL ||
-    process.env.NEXT_PUBLIC_MEDIAMTX_SERVER_API_URL ||
-    process.env.NEXT_PUBLIC_MEDIAMTX_API_URL ||
-    DEFAULT_UPSTREAM_API_URL
-
-  return configuredUrl.trim().replace(/\/+$/, "").replace(/\/v3\/config$/i, "").replace(/\/v3$/i, "")
-}
 
 function proxyHeaders(request: Request) {
   const headers = new Headers()
@@ -48,7 +38,7 @@ function responseHeaders(headers: Headers) {
 
 async function proxyMediaMtxRequest(request: Request, context: { params: Promise<{ path?: string[] }> }) {
   const { path = [] } = await context.params
-  const upstreamUrl = new URL(path.map(encodeURIComponent).join("/"), `${normalizeUpstreamApiUrl()}/`)
+  const upstreamUrl = new URL(path.map(encodeURIComponent).join("/"), `${normalizeMediaMtxServerApiBaseUrl()}/`)
   const incomingUrl = new URL(request.url)
   upstreamUrl.search = incomingUrl.search
 

--- a/lib/mediamtx-url.mjs
+++ b/lib/mediamtx-url.mjs
@@ -1,4 +1,5 @@
 const DEFAULT_API_BASE_URL = "/api/mediamtx"
+const DEFAULT_UPSTREAM_API_URL = "http://localhost:9997"
 const DEFAULT_HLS_BASE_URL = "http://localhost:8888"
 
 function trimTrailingSlashes(value) {
@@ -8,7 +9,29 @@ function trimTrailingSlashes(value) {
 export function normalizeMediaMtxApiBaseUrl(apiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL) {
   const configuredUrl = trimTrailingSlashes((apiUrl || DEFAULT_API_BASE_URL).trim())
 
-  return configuredUrl.replace(/\/v3\/config$/i, "").replace(/\/v3$/i, "") || DEFAULT_API_BASE_URL
+  return stripMediaMtxApiEndpoint(configuredUrl) || DEFAULT_API_BASE_URL
+}
+
+function stripMediaMtxApiEndpoint(value) {
+  return value
+    .replace(/\/v3\/config\/global\/get$/i, "")
+    .replace(/\/v3\/config$/i, "")
+    .replace(/\/v3$/i, "")
+}
+
+function isAbsoluteHttpUrl(value) {
+  return /^https?:\/\//i.test(value)
+}
+
+export function normalizeMediaMtxServerApiBaseUrl({
+  serverApiUrl = process.env.MEDIAMTX_API_URL,
+  legacyServerApiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_SERVER_API_URL,
+  publicApiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL,
+} = {}) {
+  const candidates = [serverApiUrl, legacyServerApiUrl, publicApiUrl].filter(Boolean).map((value) => value.trim())
+  const configuredUrl = candidates.find(isAbsoluteHttpUrl) || DEFAULT_UPSTREAM_API_URL
+
+  return stripMediaMtxApiEndpoint(trimTrailingSlashes(configuredUrl)) || DEFAULT_UPSTREAM_API_URL
 }
 
 export function buildMediaMtxApiUrl(endpoint, apiUrl = process.env.NEXT_PUBLIC_MEDIAMTX_API_URL) {

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -5,12 +5,34 @@ import {
   buildMediaMtxApiUrl,
   buildMediaMtxHlsUrl,
   normalizeMediaMtxApiBaseUrl,
+  normalizeMediaMtxServerApiBaseUrl,
 } from "../lib/mediamtx-url.mjs"
 
 assert.equal(normalizeMediaMtxApiBaseUrl(undefined), "/api/mediamtx")
 assert.equal(normalizeMediaMtxApiBaseUrl("http://localhost:9997/"), "http://localhost:9997")
 assert.equal(normalizeMediaMtxApiBaseUrl("http://localhost/v3"), "http://localhost")
 assert.equal(normalizeMediaMtxApiBaseUrl("http://localhost/v3/config"), "http://localhost")
+assert.equal(normalizeMediaMtxApiBaseUrl("http://localhost/v3/config/global/get"), "http://localhost")
+assert.equal(
+  normalizeMediaMtxServerApiBaseUrl({ publicApiUrl: "/api/mediamtx", serverApiUrl: undefined, legacyServerApiUrl: undefined }),
+  "http://localhost:9997",
+)
+assert.equal(
+  normalizeMediaMtxServerApiBaseUrl({
+    publicApiUrl: "/api/mediamtx",
+    serverApiUrl: "http://publisher:9997/v3/config/global/get",
+    legacyServerApiUrl: undefined,
+  }),
+  "http://publisher:9997",
+)
+assert.equal(
+  normalizeMediaMtxServerApiBaseUrl({
+    publicApiUrl: "http://browser.example/v3/config",
+    serverApiUrl: undefined,
+    legacyServerApiUrl: undefined,
+  }),
+  "http://browser.example",
+)
 
 assert.equal(
   buildMediaMtxApiUrl("/v3/config/global/get", "/api/mediamtx"),


### PR DESCRIPTION
## Summary
- share MediaMTX API base normalization between the browser helper and the server-side proxy
- keep relative browser-facing values like `/api/mediamtx` out of server upstream selection so the proxy falls back to `http://localhost:9997` unless a real upstream is configured
- strip copied full API endpoint values such as `/v3/config/global/get` before the proxy builds upstream URLs
- add regression assertions for the Docker default-login URL cases

## Validation
- `node scripts/test-mediamtx-url.mjs`
- `./node_modules/.bin/eslint app/api/mediamtx/'[...path]'/route.ts lib/mediamtx-url.mjs scripts/test-mediamtx-url.mjs`
- `pnpm run build`

/claim #4
