### PR TITLE
Fix MediaMTX Prometheus default auth

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -13,6 +13,9 @@ scrape_configs:
           - 'node-exporter_mediamtx:9100'
 
   - job_name: mediamtx
+    basic_auth:
+      username: admin
+      password: adminpass
     static_configs:
       - targets:
           - 'publisher:9998'

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -24,7 +24,14 @@ assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://l
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const prometheusConfig = fs.readFileSync("prometheus.yml", "utf8")
+const mediaMtxConfig = fs.readFileSync("mediamtx.yml", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+assert.ok(mediaMtxConfig.includes("- action: metrics"))
+assert.ok(prometheusConfig.includes("job_name: mediamtx"))
+assert.ok(prometheusConfig.includes("basic_auth:"))
+assert.ok(prometheusConfig.includes("username: admin"))
+assert.ok(prometheusConfig.includes("password: adminpass"))


### PR DESCRIPTION
Fixes a separate default Docker monitoring credentials gap under #4.

/claim #4

## Summary
- Add the bundled `admin` / `adminpass` credentials to the default `mediamtx` Prometheus scrape.
- Add regression assertions so `prometheus.yml` stays aligned with the `metrics` permission in `mediamtx.yml`.

## Why
The bundled `mediamtx.yml` grants the `metrics` action to the `admin` user. Prometheus scrapes `publisher:9998` from a separate container in the compose network, so it should use the same default credentials instead of relying on unauthenticated localhost behavior.

## Verification
- `node scripts/test-mediamtx-url.mjs`
- `git diff --check`

This is configuration-only, so the proof is the default scrape config plus the regression check rather than a UI recording.