### PR TITLE
Fix dev compose MediaMTX upstream defaults

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -69,6 +69,10 @@ services:
       - "3000:3000"
     env_file:
       - ./.env
+    environment:
+      MEDIAMTX_API_URL: ${MEDIAMTX_API_URL:-http://publisher:9997}
+      NEXT_PUBLIC_MEDIAMTX_API_URL: ${NEXT_PUBLIC_MEDIAMTX_API_URL:-/api/mediamtx}
+      NEXT_PUBLIC_MEDIAMTX_HLS_URL: ${NEXT_PUBLIC_MEDIAMTX_HLS_URL:-http://localhost/hls}
         #depends_on:
         #  publisher:
         #    <<: *depends_on_healthy

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -24,7 +24,10 @@ assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://l
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const devCompose = fs.readFileSync("docker-compose.dev.yml", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+assert.ok(devCompose.includes("MEDIAMTX_API_URL: ${MEDIAMTX_API_URL:-http://publisher:9997}"))
+assert.ok(devCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL: ${NEXT_PUBLIC_MEDIAMTX_API_URL:-/api/mediamtx}"))


### PR DESCRIPTION
/claim #4

This PR fixes a focused dev-compose default-login edge case that is separate from the already-open env-file, pull-policy, proxy-normalization, healthcheck, helper-script, and Dockerfile PRs.

`docker-compose.dev.yml` starts the dashboard container without any server-side `MEDIAMTX_API_URL` default. When `.env` is missing or does not define it, the Next.js `/api/mediamtx` proxy can fall back to `http://localhost:9997` inside the dashboard container. In that context `localhost` is the dashboard container, not the `publisher` MediaMTX service, so the default `admin` / `adminpass` login path can still fail in the dev compose stack.

Changes:
- set the dev dashboard service `MEDIAMTX_API_URL` default to `http://publisher:9997`
- keep the browser-facing API default as `/api/mediamtx`
- keep the HLS default aligned with the main compose stack
- add regression assertions to `scripts/test-mediamtx-url.mjs`

Verification:
- `node scripts/test-mediamtx-url.mjs`
- `node --check scripts/test-mediamtx-url.mjs`
- `git diff --check`

AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.