### PR TITLE
Make default Docker compose self-contained

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,8 +95,6 @@ services:
     depends_on:
       - publisher
     restart: unless-stopped
-    env_file:
-      - ./.env
     environment:
       MEDIAMTX_API_URL: ${MEDIAMTX_API_URL:-http://publisher:9997}
       NEXT_PUBLIC_MEDIAMTX_API_URL: ${NEXT_PUBLIC_MEDIAMTX_API_URL:-/api/mediamtx}

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -23,8 +23,12 @@ assert.equal(
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
+const defaultCompose = fs.readFileSync("docker-compose.yml", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
+assert.ok(!defaultCompose.includes("env_file:"))
+assert.ok(defaultCompose.includes("MEDIAMTX_API_URL: ${MEDIAMTX_API_URL:-http://publisher:9997}"))
+assert.ok(defaultCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL: ${NEXT_PUBLIC_MEDIAMTX_API_URL:-/api/mediamtx}"))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))


### PR DESCRIPTION
## Summary
- remove the hard `./.env` env_file dependency from the default Docker Compose dashboard service
- keep the existing inline Docker defaults so the dashboard proxy still reaches `http://publisher:9997` and the browser uses `/api/mediamtx`
- add regression assertions to the existing MediaMTX URL/config test so fresh-clone compose defaults do not regress

## Validation
- `npm test`
- `npm run build`
- `git diff --check`

Could not run `docker compose config` or a full Docker stack locally because Docker is not installed in this worker environment (`zsh: command not found: docker`).

/claim #4