### PR TITLE
Wait for local MediaMTX API readiness

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -16,6 +16,12 @@ services:
       - ./recordings:/recordings
     environment:
       - MTX_PROTOCOLS=tcp
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "--header", "Authorization: Basic YWRtaW46YWRtaW5wYXNz", "http://localhost:9997/v3/config/global/get"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
     networks:
       - mediamtx-network
 

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -23,6 +23,20 @@ case $choice in
         echo ""
         echo "Starting MediaMTX server only..."
         docker-compose -f docker-compose.local.yml up -d
+        echo "Waiting for the MediaMTX API to accept the default credentials..."
+        mediamtx_ready=0
+        for attempt in {1..30}; do
+            if curl -fsS -u admin:adminpass http://localhost:9997/v3/config/global/get > /dev/null 2>&1; then
+                mediamtx_ready=1
+                break
+            fi
+            sleep 1
+        done
+        if [ "$mediamtx_ready" != "1" ]; then
+            echo "❌ MediaMTX API did not become ready with admin/adminpass."
+            echo "   Check logs with: docker-compose -f docker-compose.local.yml logs mediamtx"
+            exit 1
+        fi
         echo ""
         echo "✅ MediaMTX is running!"
         echo ""

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -23,8 +23,14 @@ assert.equal(
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
+const localCompose = fs.readFileSync("docker-compose.local.yml", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const quickStart = fs.readFileSync("scripts/quick-start.sh", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
+assert.match(localCompose, /mediamtx:\r?\n[\s\S]*?healthcheck:/)
+assert.ok(localCompose.includes("Authorization: Basic YWRtaW46YWRtaW5wYXNz"))
+assert.ok(quickStart.includes("curl -fsS -u admin:adminpass http://localhost:9997/v3/config/global/get"))
+assert.ok(quickStart.includes("MediaMTX API did not become ready with admin/adminpass."))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))


### PR DESCRIPTION
## Summary
- add an authenticated API healthcheck to `docker-compose.local.yml`
- make quick-start option 1 wait until `http://localhost:9997/v3/config/global/get` accepts the default `admin` / `adminpass` credentials
- add regression assertions so the local quick-start path keeps testing the authenticated API readiness gate

## Why
The local quick-start path starts only MediaMTX through `docker-compose.local.yml`, then tells users to run the dashboard locally and test the bundled credentials. Without a local MediaMTX readiness gate, the script can report success while the authenticated API is still coming up, leaving a short window where the next dashboard login can fail even though `admin` / `adminpass` is correct.

This is scoped away from the already-open default-compose, production-compose, Makefile health, Compose v2 helper, and quick-start package-manager PRs. It only covers the local MediaMTX-only quick-start flow.

## Validation
- `npm test`
- `bash -n scripts/quick-start.sh`
- `git diff --check`
- `ruby -e "require \"yaml\"; YAML.load_file(\"docker-compose.local.yml\"); puts \"yaml ok\""`

Docker CLI is not installed in this worker environment (`zsh: command not found: docker`), so I could not run `docker compose config` or a live container smoke test here.

## Demo
The regression test now verifies that `docker-compose.local.yml` has the authenticated MediaMTX API healthcheck and that quick-start option 1 waits for `admin:adminpass` to reach `/v3/config/global/get` before showing the local dashboard next steps.

/claim #4