### PR TITLE
[codex] Redact stream source credentials

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -41,6 +41,7 @@ import {
 } from "lucide-react"
 import { ProtectedRoute } from "@/components/protected-route"
 import { clearAuth, getUsername } from "@/lib/auth"
+import { redactMediaMtxSourceUrl } from "@/lib/mediamtx-url.mjs"
 import { StreamPlayer } from "@/components/stream-player"
 import * as api from "@/lib/mediamtx-api"
 import type { PathConfig, Path as LivePath } from "@/lib/mediamtx-api"
@@ -366,7 +367,7 @@ function MediaMTXDashboard() {
                                     </Badge>
                                   )}
                                 </div>
-                                <p className="text-sm text-gray-500">{path.source}</p>
+                                <p className="text-sm text-gray-500">{redactMediaMtxSourceUrl(path.source)}</p>
                                 <div className="flex items-center gap-4 mt-1 text-xs text-gray-500">
                                   <span>{status.readers} viewers</span>
                                   {status.isLive && (

--- a/lib/mediamtx-url.mjs
+++ b/lib/mediamtx-url.mjs
@@ -1,5 +1,6 @@
 const DEFAULT_API_BASE_URL = "/api/mediamtx"
 const DEFAULT_HLS_BASE_URL = "http://localhost:8888"
+const URL_CREDENTIALS_PATTERN = /\b([a-z][a-z0-9+.-]*:\/\/)([^/\s?#@]+(?::[^/\s?#@]*)?)@/gi
 
 function trimTrailingSlashes(value) {
   return value.replace(/\/+$/, "")
@@ -25,4 +26,12 @@ export function buildMediaMtxHlsUrl(pathName, hlsUrl = process.env.NEXT_PUBLIC_M
   const normalizedPathName = pathName.replace(/^\/+/, "")
 
   return `${normalizeMediaMtxHlsBaseUrl(hlsUrl)}/${normalizedPathName}/index.m3u8`
+}
+
+export function redactMediaMtxSourceUrl(sourceUrl) {
+  if (typeof sourceUrl !== "string") {
+    return sourceUrl
+  }
+
+  return sourceUrl.replace(URL_CREDENTIALS_PATTERN, "$1[redacted]@")
 }

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -5,6 +5,7 @@ import {
   buildMediaMtxApiUrl,
   buildMediaMtxHlsUrl,
   normalizeMediaMtxApiBaseUrl,
+  redactMediaMtxSourceUrl,
 } from "../lib/mediamtx-url.mjs"
 
 assert.equal(normalizeMediaMtxApiBaseUrl(undefined), "/api/mediamtx")
@@ -21,6 +22,15 @@ assert.equal(
   "http://localhost/v3/config/global/get",
 )
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
+assert.equal(
+  redactMediaMtxSourceUrl("rtsp://admin:Admin1234@192.168.50.50/live"),
+  "rtsp://[redacted]@192.168.50.50/live",
+)
+assert.equal(
+  redactMediaMtxSourceUrl("rtsps://camera-user@camera.example.com/stream"),
+  "rtsps://[redacted]@camera.example.com/stream",
+)
+assert.equal(redactMediaMtxSourceUrl("publisher"), "publisher")
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")


### PR DESCRIPTION
## Summary
- Add a dependency-free MediaMTX URL redaction helper for display-only source URLs.
- Redact credentials in stream source rows such as `rtsp://user:password@host/path` while preserving the raw source value for API/config operations.
- Add regression coverage for password-bearing, username-only, and publisher-style sources.

## Security impact
Authenticated dashboard users can currently expose upstream camera credentials when the stream list is screenshotted, shared, or observed over the shoulder. This keeps the dashboard useful while avoiding accidental disclosure of embedded RTSP/RTSPS credentials.

## Validation
- `npm test`
- `npm run build`
- `git diff --check`

No live MediaMTX instances, credentials, or private data were accessed. This change was prepared with AI assistance and manually scoped/reviewed.

/claim #4
