### PR TITLE
Make MediaMTX updater honor Docker API env

### DIFF
--- a/mediamtx_updater.py
+++ b/mediamtx_updater.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import logging
+import os
 import requests
 import json
 import time
@@ -7,21 +8,50 @@ import sys
 from requests.auth import HTTPBasicAuth
 
 # Configuration
-MEDIAMTX_API_URL = "http://localhost:9997/v3/config/paths/list"
-MEDIAMTX_CONFIG_PATH = "./mediamtx.yml"  # Update this to your actual path
-MEDIAMTX_USERNAME = "admin"
-MEDIAMTX_PASSWORD = "adminpass"
-UPDATE_INTERVAL = 60  # seconds
+DEFAULT_MEDIAMTX_API_URL = "http://localhost:9997"
+MEDIAMTX_PATHS_ENDPOINT = "/v3/config/paths/list"
 
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler('mediamtx_updater.log'),
-        logging.StreamHandler()
-    ]
-)
+
+def build_mediamtx_paths_url(api_url):
+    """Accept either a MediaMTX API base URL or the full paths endpoint."""
+    normalized_url = (api_url or "").strip().rstrip("/") or DEFAULT_MEDIAMTX_API_URL
+
+    if normalized_url.endswith(MEDIAMTX_PATHS_ENDPOINT):
+        return normalized_url
+
+    if normalized_url.endswith("/v3/config"):
+        normalized_url = normalized_url.removesuffix("/v3/config")
+    elif normalized_url.endswith("/v3"):
+        normalized_url = normalized_url.removesuffix("/v3")
+
+    return f"{normalized_url}{MEDIAMTX_PATHS_ENDPOINT}"
+
+
+def parse_update_interval(value, default=60):
+    try:
+        interval = int(value)
+    except (TypeError, ValueError):
+        return default
+
+    return interval if interval > 0 else default
+
+
+MEDIAMTX_API_URL = build_mediamtx_paths_url(os.getenv("MEDIAMTX_API_URL"))
+MEDIAMTX_CONFIG_PATH = os.getenv("MEDIAMTX_CONFIG_PATH", "./mediamtx.yml")
+MEDIAMTX_USERNAME = os.getenv("MEDIAMTX_USERNAME", "admin")
+MEDIAMTX_PASSWORD = os.getenv("MEDIAMTX_PASSWORD", "adminpass")
+UPDATE_INTERVAL = parse_update_interval(os.getenv("MEDIAMTX_UPDATE_INTERVAL"))
+
+
+def configure_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        handlers=[
+            logging.FileHandler('mediamtx_updater.log'),
+            logging.StreamHandler()
+        ]
+    )
 
 def debug_response_structure(config_data):
     """Debug function to understand the response structure"""
@@ -255,6 +285,8 @@ def check_mediamtx_connectivity():
         return False
 
 def main():
+    configure_logging()
+
     # First, check connectivity
     logging.info("MediaMTX Configuration Updater started")
     logging.info(f"Using username: {MEDIAMTX_USERNAME}")

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "test": "node scripts/test-mediamtx-url.mjs",
+    "test": "node scripts/test-mediamtx-url.mjs && python scripts/test-mediamtx-updater-config.py",
     "start": "next start"
   },
   "dependencies": {

--- a/scripts/test-mediamtx-updater-config.py
+++ b/scripts/test-mediamtx-updater-config.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "mediamtx_updater.py"
+
+spec = importlib.util.spec_from_file_location("mediamtx_updater_under_test", MODULE_PATH)
+mediamtx_updater = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mediamtx_updater)
+
+assert (
+    mediamtx_updater.build_mediamtx_paths_url("http://publisher:9997")
+    == "http://publisher:9997/v3/config/paths/list"
+)
+assert (
+    mediamtx_updater.build_mediamtx_paths_url("http://publisher:9997/")
+    == "http://publisher:9997/v3/config/paths/list"
+)
+assert (
+    mediamtx_updater.build_mediamtx_paths_url("http://publisher:9997/v3/config/paths/list")
+    == "http://publisher:9997/v3/config/paths/list"
+)
+assert (
+    mediamtx_updater.build_mediamtx_paths_url("http://publisher:9997/v3/config")
+    == "http://publisher:9997/v3/config/paths/list"
+)
+assert (
+    mediamtx_updater.build_mediamtx_paths_url("http://publisher:9997/v3")
+    == "http://publisher:9997/v3/config/paths/list"
+)
+assert mediamtx_updater.build_mediamtx_paths_url(None) == "http://localhost:9997/v3/config/paths/list"
+assert mediamtx_updater.build_mediamtx_paths_url("   ") == "http://localhost:9997/v3/config/paths/list"
+
+assert mediamtx_updater.parse_update_interval("5") == 5
+assert mediamtx_updater.parse_update_interval("0") == 60
+assert mediamtx_updater.parse_update_interval("-1") == 60
+assert mediamtx_updater.parse_update_interval("not-a-number") == 60


### PR DESCRIPTION
/claim #4

## Summary
- Make `mediamtx_updater.py` honor the same Docker-facing env surface as the dashboard stack: `MEDIAMTX_API_URL`, `MEDIAMTX_USERNAME`, `MEDIAMTX_PASSWORD`, `MEDIAMTX_CONFIG_PATH`, and `MEDIAMTX_UPDATE_INTERVAL`.
- Accept either a MediaMTX API base URL such as `http://publisher:9997` or the full `/v3/config/paths/list` endpoint, preserving the existing localhost/default credential behavior.
- Move logging setup into `main()` so the updater can be imported by regression tests without creating `mediamtx_updater.log`.
- Add direct regression coverage for the updater URL and interval parsing helpers.

## Why this is separate
The existing Docker/login PRs focus on the Next.js browser/API proxy, compose healthchecks, Dockerfiles, and shell helpers. This patch covers the standalone Python updater path, which still could not consume the Docker stack's documented base `MEDIAMTX_API_URL` value correctly.

## Demo video
https://github.com/user-attachments/assets/2c93600d-8010-4e9a-b8d5-86540836feca

## Validation
- `npm test`
- `python -m py_compile mediamtx_updater.py scripts/test-mediamtx-updater-config.py`
- `git diff --check`

AI-assisted with OpenAI Codex; I reviewed the diff and validation before submitting.