### PR TITLE
Handle MediaMTX proxy preflight requests

### DIFF
--- a/app/api/mediamtx/[...path]/route.ts
+++ b/app/api/mediamtx/[...path]/route.ts
@@ -1,4 +1,6 @@
 const DEFAULT_UPSTREAM_API_URL = "http://localhost:9997"
+const PROXY_ALLOWED_METHODS = "GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS"
+const PROXY_ALLOWED_HEADERS = "Authorization, Content-Type"
 
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
@@ -46,6 +48,45 @@ function responseHeaders(headers: Headers) {
   return responseHeaders
 }
 
+function corsHeaders(request: Request) {
+  const headers = new Headers()
+  const origin = request.headers.get("origin")
+  const requestedHeaders = request.headers.get("access-control-request-headers")
+
+  headers.set("Access-Control-Allow-Origin", origin || "*")
+  headers.set("Access-Control-Allow-Methods", PROXY_ALLOWED_METHODS)
+  headers.set("Access-Control-Allow-Headers", requestedHeaders || PROXY_ALLOWED_HEADERS)
+  headers.set("Access-Control-Max-Age", "86400")
+  headers.set("Vary", "Origin, Access-Control-Request-Headers")
+
+  return headers
+}
+
+function appendVaryHeader(headers: Headers, value: string) {
+  const existingValues = headers.get("Vary")?.split(",").map((header) => header.trim()).filter(Boolean) || []
+  const nextValues = value.split(",").map((header) => header.trim()).filter(Boolean)
+
+  headers.set("Vary", Array.from(new Set([...existingValues, ...nextValues])).join(", "))
+}
+
+function withCorsHeaders(headers: Headers, request: Request) {
+  const nextHeaders = new Headers(headers)
+  const corsResponseHeaders = corsHeaders(request)
+  const varyHeader = corsResponseHeaders.get("Vary")
+
+  corsResponseHeaders.delete("Vary")
+
+  for (const [header, value] of corsResponseHeaders) {
+    nextHeaders.set(header, value)
+  }
+
+  if (varyHeader) {
+    appendVaryHeader(nextHeaders, varyHeader)
+  }
+
+  return nextHeaders
+}
+
 async function proxyMediaMtxRequest(request: Request, context: { params: Promise<{ path?: string[] }> }) {
   const { path = [] } = await context.params
   const upstreamUrl = new URL(path.map(encodeURIComponent).join("/"), `${normalizeUpstreamApiUrl()}/`)
@@ -63,11 +104,19 @@ async function proxyMediaMtxRequest(request: Request, context: { params: Promise
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
-    headers: responseHeaders(response.headers),
+    headers: withCorsHeaders(responseHeaders(response.headers), request),
+  })
+}
+
+export function OPTIONS(request: Request) {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders(request),
   })
 }
 
 export const GET = proxyMediaMtxRequest
+export const HEAD = proxyMediaMtxRequest
 export const POST = proxyMediaMtxRequest
 export const PUT = proxyMediaMtxRequest
 export const PATCH = proxyMediaMtxRequest

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -24,7 +24,14 @@ assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://l
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const mediaMtxProxyRoute = fs.readFileSync("app/api/mediamtx/[...path]/route.ts", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+
+assert.ok(mediaMtxProxyRoute.includes("export function OPTIONS"))
+assert.ok(mediaMtxProxyRoute.includes("export const HEAD = proxyMediaMtxRequest"))
+assert.ok(mediaMtxProxyRoute.includes("GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS"))
+assert.ok(mediaMtxProxyRoute.includes("Access-Control-Allow-Headers"))
+assert.ok(mediaMtxProxyRoute.includes("access-control-request-headers"))


### PR DESCRIPTION
/claim #4

## Summary
- Add an explicit `OPTIONS` handler for the same-origin `/api/mediamtx` proxy so browser Authorization preflights get CORS headers instead of only Next.js' automatic `Allow` response.
- Add a `HEAD` export that reuses the proxy path for bodyless probes.
- Apply the same CORS headers to proxied responses while preserving any upstream `Vary` header.
- Add regression assertions to the existing dependency-free MediaMTX URL/config test.

## Why this is separate
The nginx `/v3/` proxy already has explicit CORS handling, but the Next.js `/api/mediamtx` proxy introduced for Docker login does not. If users configure `NEXT_PUBLIC_MEDIAMTX_API_URL` as an absolute dashboard proxy URL from a different browser origin, the browser can fail the `Authorization` preflight before the default `admin/adminpass` request reaches MediaMTX.

## Demo
Validated the built Next.js route with a preflight request:

```sh
curl -i -X OPTIONS 'http://localhost:3210/api/mediamtx/v3/config/global/get' \
  -H 'Origin: http://example.test' \
  -H 'Access-Control-Request-Method: GET' \
  -H 'Access-Control-Request-Headers: authorization,content-type'
```

The route returns `204 No Content` with:

```text
access-control-allow-origin: http://example.test
access-control-allow-methods: GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
access-control-allow-headers: authorization,content-type
access-control-max-age: 86400
```

## Validation
- `npm test`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm install --frozen-lockfile`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm run build`
- `git diff --check`

`pnpm run build` succeeds; it prints the existing Next.js workspace-root warning because this checkout lives under a parent directory with another lockfile. No application build error.

AI-assisted with OpenAI Codex; I reviewed the diff and local validation before submitting.
