### PR TITLE
fix: fetch all pages from MediaMTX list endpoints

### DIFF
--- a/lib/mediamtx-api.ts
+++ b/lib/mediamtx-api.ts
@@ -1,6 +1,12 @@
 import { getAuthHeader } from "./auth"
 import { buildMediaMtxApiUrl } from "./mediamtx-url.mjs"
 
+interface PagedList<T> {
+  pageCount: number
+  itemCount: number
+  items: T[]
+}
+
 export interface PathConfig {
   name: string
   source: string
@@ -79,14 +85,35 @@ async function fetchAPI(endpoint: string, options: RequestInit = {}) {
   return text
 }
 
+// Collects every page of a paginated MediaMTX list endpoint.
+// MediaMTX uses 0-based page numbers and returns pageCount in each response.
+async function fetchAllPages<T>(endpoint: string): Promise<T[]> {
+  const first = (await fetchAPI(`${endpoint}?page=0`)) as PagedList<T>
+  const all: T[] = Array.isArray(first?.items) ? [...first.items] : []
+  const pageCount = first?.pageCount ?? 1
+
+  if (pageCount <= 1) return all
+
+  // Fetch remaining pages in parallel — safe for typical deployments.
+  const rest = await Promise.all(
+    Array.from({ length: pageCount - 1 }, (_, i) =>
+      fetchAPI(`${endpoint}?page=${i + 1}`) as Promise<PagedList<T>>,
+    ),
+  )
+
+  for (const page of rest) {
+    if (Array.isArray(page?.items)) all.push(...page.items)
+  }
+
+  return all
+}
+
 export async function getPathConfigs(): Promise<PathConfig[]> {
-  const data = await fetchAPI("/v3/config/paths/list")
-  return data.items || []
+  return fetchAllPages<PathConfig>("/v3/config/paths/list")
 }
 
 export async function getPaths(): Promise<Path[]> {
-  const data = await fetchAPI("/v3/paths/list")
-  return data.items || []
+  return fetchAllPages<Path>("/v3/paths/list")
 }
 
 export async function addPath(config: PathConfig): Promise<void> {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "test": "node scripts/test-mediamtx-url.mjs",
+    "test": "node scripts/test-mediamtx-url.mjs && node scripts/test-pagination.mjs",
     "start": "next start"
   },
   "dependencies": {

--- a/scripts/test-pagination.mjs
+++ b/scripts/test-pagination.mjs
@@ -1,0 +1,170 @@
+/**
+ * Tests for the paginated MediaMTX list fetching.
+ *
+ * Validates that all pages are collected when pageCount > 1, that a single-page
+ * response is handled without extra requests, and that sparse/null items arrays
+ * never cause a crash.
+ */
+
+import assert from "node:assert/strict"
+
+// ---------------------------------------------------------------------------
+// Pure re-implementation of fetchAllPages — same logic, accepts a fetcher so
+// we can drive it from Node without a browser or a live MediaMTX instance.
+// ---------------------------------------------------------------------------
+
+async function fetchAllPages(endpoint, fetcher) {
+  const first = await fetcher(`${endpoint}?page=0`)
+  const all = Array.isArray(first?.items) ? [...first.items] : []
+  const pageCount = first?.pageCount ?? 1
+
+  if (pageCount <= 1) return all
+
+  const rest = await Promise.all(
+    Array.from({ length: pageCount - 1 }, (_, i) =>
+      fetcher(`${endpoint}?page=${i + 1}`),
+    ),
+  )
+
+  for (const page of rest) {
+    if (Array.isArray(page?.items)) all.push(...page.items)
+  }
+
+  return all
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFetcher(pages) {
+  const calls = []
+  const fetcher = async (url) => {
+    calls.push(url)
+    const match = url.match(/[?&]page=(\d+)/)
+    const pageIndex = match ? parseInt(match[1], 10) : 0
+    return pages[pageIndex]
+  }
+  fetcher.calls = calls
+  return fetcher
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let passed = 0
+let failed = 0
+
+async function test(name, fn) {
+  try {
+    await fn()
+    console.log(`  ✓ ${name}`)
+    passed++
+  } catch (err) {
+    console.error(`  ✗ ${name}`)
+    console.error(`    ${err.message}`)
+    failed++
+  }
+}
+
+console.log("pagination tests")
+
+await test("single page — returns items without extra fetches", async () => {
+  const pages = [{ pageCount: 1, itemCount: 2, items: [{ name: "a" }, { name: "b" }] }]
+  const fetcher = makeFetcher(pages)
+
+  const result = await fetchAllPages("/v3/paths/list", fetcher)
+
+  assert.equal(result.length, 2)
+  assert.equal(result[0].name, "a")
+  assert.equal(fetcher.calls.length, 1)
+  assert.ok(fetcher.calls[0].includes("page=0"))
+})
+
+await test("two pages — all items returned in order", async () => {
+  const pages = [
+    { pageCount: 2, itemCount: 3, items: [{ name: "a" }, { name: "b" }] },
+    { pageCount: 2, itemCount: 3, items: [{ name: "c" }] },
+  ]
+  const fetcher = makeFetcher(pages)
+
+  const result = await fetchAllPages("/v3/paths/list", fetcher)
+
+  assert.equal(result.length, 3)
+  assert.deepEqual(
+    result.map((r) => r.name),
+    ["a", "b", "c"],
+  )
+  assert.equal(fetcher.calls.length, 2)
+})
+
+await test("three pages — all items from all pages", async () => {
+  const pages = [
+    { pageCount: 3, itemCount: 7, items: Array.from({ length: 3 }, (_, i) => ({ name: `s${i}` })) },
+    { pageCount: 3, itemCount: 7, items: Array.from({ length: 3 }, (_, i) => ({ name: `s${i + 3}` })) },
+    { pageCount: 3, itemCount: 7, items: [{ name: "s6" }] },
+  ]
+  const fetcher = makeFetcher(pages)
+
+  const result = await fetchAllPages("/v3/paths/list", fetcher)
+
+  assert.equal(result.length, 7)
+  assert.equal(fetcher.calls.length, 3)
+  assert.ok(fetcher.calls.some((c) => c.includes("page=2")))
+})
+
+await test("missing pageCount — treated as single page, no extra requests", async () => {
+  const pages = [{ items: [{ name: "x" }] }] // pageCount absent
+  const fetcher = makeFetcher(pages)
+
+  const result = await fetchAllPages("/v3/paths/list", fetcher)
+
+  assert.equal(result.length, 1)
+  assert.equal(fetcher.calls.length, 1)
+})
+
+await test("null items array — returns empty list without crashing", async () => {
+  const pages = [{ pageCount: 1, itemCount: 0, items: null }]
+  const fetcher = makeFetcher(pages)
+
+  const result = await fetchAllPages("/v3/paths/list", fetcher)
+
+  assert.equal(result.length, 0)
+})
+
+await test("second page has null items — skipped gracefully", async () => {
+  const pages = [
+    { pageCount: 2, itemCount: 1, items: [{ name: "a" }] },
+    { pageCount: 2, itemCount: 1, items: null },
+  ]
+  const fetcher = makeFetcher(pages)
+
+  const result = await fetchAllPages("/v3/paths/list", fetcher)
+
+  assert.equal(result.length, 1)
+  assert.equal(result[0].name, "a")
+})
+
+await test("config/paths/list endpoint uses correct page param", async () => {
+  const pages = [
+    { pageCount: 2, itemCount: 2, items: [{ name: "cam1", source: "rtsp://x" }] },
+    { pageCount: 2, itemCount: 2, items: [{ name: "cam2", source: "rtsp://y" }] },
+  ]
+  const fetcher = makeFetcher(pages)
+
+  const result = await fetchAllPages("/v3/config/paths/list", fetcher)
+
+  assert.equal(result.length, 2)
+  assert.ok(fetcher.calls[0].includes("/v3/config/paths/list?page=0"))
+  assert.ok(fetcher.calls[1].includes("/v3/config/paths/list?page=1"))
+})
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log("")
+console.log(`${passed} passed, ${failed} failed`)
+
+if (failed > 0) process.exit(1)


### PR DESCRIPTION
`getPathConfigs()` and `getPaths()` never passed `?page=`, so only the first 100 items were returned. Deployments with 100+ paths silently showed an incomplete list (root cause of #21).

The MediaMTX API returns `pageCount` in every list response — the dashboard never read it.

Added `fetchAllPages<T>()` that reads `pageCount` from page 0, then fetches all remaining pages in parallel and returns the merged result. Single-page responses trigger no extra requests.

`scripts/test-pagination.mjs` added (7 cases: single page, multi-page ordering, missing `pageCount`, null `items`, per-endpoint query params). `npm test`, `tsc --noEmit`, and `next lint` all pass.

/claim #4