### PR TITLE
Encode HLS stream path segments

### DIFF
--- a/lib/mediamtx-url.mjs
+++ b/lib/mediamtx-url.mjs
@@ -21,8 +21,14 @@ export function normalizeMediaMtxHlsBaseUrl(hlsUrl = process.env.NEXT_PUBLIC_MED
   return trimTrailingSlashes((hlsUrl || DEFAULT_HLS_BASE_URL).trim())
 }
 
-export function buildMediaMtxHlsUrl(pathName, hlsUrl = process.env.NEXT_PUBLIC_MEDIAMTX_HLS_URL) {
-  const normalizedPathName = pathName.replace(/^\/+/, "")
+function encodeMediaMtxHlsPathName(pathName) {
+  return pathName
+    .replace(/^\/+/, "")
+    .split("/")
+    .map((pathSegment) => encodeURIComponent(pathSegment))
+    .join("/")
+}
 
-  return `${normalizeMediaMtxHlsBaseUrl(hlsUrl)}/${normalizedPathName}/index.m3u8`
+export function buildMediaMtxHlsUrl(pathName, hlsUrl = process.env.NEXT_PUBLIC_MEDIAMTX_HLS_URL) {
+  return `${normalizeMediaMtxHlsBaseUrl(hlsUrl)}/${encodeMediaMtxHlsPathName(pathName)}/index.m3u8`
 }

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -21,6 +21,14 @@ assert.equal(
   "http://localhost/v3/config/global/get",
 )
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
+assert.equal(
+  buildMediaMtxHlsUrl("camera 1", "http://localhost/hls/"),
+  "http://localhost/hls/camera%201/index.m3u8",
+)
+assert.equal(
+  buildMediaMtxHlsUrl("floor 1/cam #2?main", "http://localhost/hls/"),
+  "http://localhost/hls/floor%201/cam%20%232%3Fmain/index.m3u8",
+)
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")


### PR DESCRIPTION
/claim #4

## Summary
- Encode each MediaMTX HLS stream path segment before building the dashboard player manifest URL.
- Preserve nested MediaMTX path separators while escaping spaces and reserved URL characters such as `#` and `?`.
- Add regression assertions to the existing URL helper test script.

## Why this is separate
The existing Docker/default-login fixes route the dashboard to MediaMTX successfully, but the player still appends raw stream names to the HLS manifest URL. After login, valid MediaMTX paths such as `camera 1` or `floor 1/cam #2?main` can produce broken browser/HLS.js URLs because reserved characters are interpreted as URL syntax instead of path data.

This patch is scoped to playback URL construction only; it does not change the API proxy, Docker defaults, auth flow, or raw MediaMTX path names sent to the API.

## Demo / proof
The regression test now covers these URL shapes:

```text
camera 1 -> http://localhost/hls/camera%201/index.m3u8
floor 1/cam #2?main -> http://localhost/hls/floor%201/cam%20%232%3Fmain/index.m3u8
```

Nested path separators remain path separators, while each segment is safely encoded.

## Validation
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm install --frozen-lockfile`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm test`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm exec tsc --noEmit --pretty false`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm run build`
- `git diff --check`

AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.