### PR TITLE
Handle MediaMTX proxy preflights

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -48,6 +48,7 @@ DASHBOARD_PORT=3000
 NEXT_PUBLIC_MEDIAMTX_API_URL=/api/mediamtx
 MEDIAMTX_API_URL=http://publisher:9997
 NEXT_PUBLIC_MEDIAMTX_HLS_URL=http://localhost/hls
+MEDIAMTX_PROXY_ALLOWED_ORIGINS=
 
 # MediaMTX Ports
 RTSP_PORT=8554
@@ -61,6 +62,8 @@ METRICS_PORT=9998
 MEDIAMTX_USERNAME=admin
 MEDIAMTX_PASSWORD=adminpass
 \`\`\`
+
+`MEDIAMTX_PROXY_ALLOWED_ORIGINS` is optional. Leave it empty for the default same-origin `/api/mediamtx` proxy behavior, or set a comma-separated list of exact browser origins when a separate dashboard origin must call the proxy.
 
 ### MediaMTX Configuration
 

--- a/app/api/mediamtx/[...path]/route.ts
+++ b/app/api/mediamtx/[...path]/route.ts
@@ -1,3 +1,5 @@
+import { appendVaryHeader, corsHeaders, PROXY_HEADERS } from "../../../../lib/mediamtx-proxy-cors.mjs"
+
 const DEFAULT_UPSTREAM_API_URL = "http://localhost:9997"
 
 const HOP_BY_HOP_HEADERS = new Set([
@@ -26,7 +28,7 @@ function normalizeUpstreamApiUrl() {
 function proxyHeaders(request: Request) {
   const headers = new Headers()
 
-  for (const header of ["accept", "authorization", "content-type"]) {
+  for (const header of PROXY_HEADERS) {
     const value = request.headers.get(header)
     if (value) {
       headers.set(header, value)
@@ -36,11 +38,23 @@ function proxyHeaders(request: Request) {
   return headers
 }
 
-function responseHeaders(headers: Headers) {
+function responseHeaders(headers: Headers, request: Request) {
   const responseHeaders = new Headers(headers)
 
   for (const header of HOP_BY_HOP_HEADERS) {
     responseHeaders.delete(header)
+  }
+
+  const corsResponseHeaders = corsHeaders(request)
+  const varyHeader = corsResponseHeaders.get("vary")
+  corsResponseHeaders.delete("vary")
+
+  for (const [header, value] of corsResponseHeaders) {
+    responseHeaders.set(header, value)
+  }
+
+  if (varyHeader) {
+    appendVaryHeader(responseHeaders, varyHeader)
   }
 
   return responseHeaders
@@ -63,11 +77,19 @@ async function proxyMediaMtxRequest(request: Request, context: { params: Promise
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
-    headers: responseHeaders(response.headers),
+    headers: responseHeaders(response.headers, request),
+  })
+}
+
+export function OPTIONS(request: Request) {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders(request),
   })
 }
 
 export const GET = proxyMediaMtxRequest
+export const HEAD = proxyMediaMtxRequest
 export const POST = proxyMediaMtxRequest
 export const PUT = proxyMediaMtxRequest
 export const PATCH = proxyMediaMtxRequest

--- a/lib/mediamtx-proxy-cors.mjs
+++ b/lib/mediamtx-proxy-cors.mjs
@@ -1,0 +1,63 @@
+const DEFAULT_ALLOWED_HEADERS = ["accept", "authorization", "content-type"]
+
+export const PROXY_ALLOWED_METHODS = "GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS"
+export const PROXY_ALLOWED_HEADERS = "Accept, Authorization, Content-Type"
+export const PROXY_HEADERS = ["Accept", "Authorization", "Content-Type"]
+
+function parseAllowedOrigins(value) {
+  return (value || "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean)
+}
+
+function isAllowedOrigin(request, origin, configuredOrigins = process.env.MEDIAMTX_PROXY_ALLOWED_ORIGINS) {
+  if (!origin) {
+    return true
+  }
+
+  const requestOrigin = new URL(request.url).origin
+  const allowedOrigins = parseAllowedOrigins(configuredOrigins)
+
+  return origin === requestOrigin || allowedOrigins.includes(origin)
+}
+
+function allowedRequestedHeaders(request) {
+  const requestedHeaders = request.headers.get("access-control-request-headers")
+
+  if (!requestedHeaders) {
+    return PROXY_ALLOWED_HEADERS
+  }
+
+  const allowedHeaders = requestedHeaders
+    .split(",")
+    .map((header) => header.trim().toLowerCase())
+    .filter((header) => DEFAULT_ALLOWED_HEADERS.includes(header))
+
+  return allowedHeaders.length ? allowedHeaders.join(", ") : PROXY_ALLOWED_HEADERS
+}
+
+export function corsHeaders(request, configuredOrigins = process.env.MEDIAMTX_PROXY_ALLOWED_ORIGINS) {
+  const headers = new Headers()
+  const origin = request.headers.get("origin")
+
+  headers.set("vary", "Origin, Access-Control-Request-Headers")
+
+  if (!isAllowedOrigin(request, origin, configuredOrigins)) {
+    return headers
+  }
+
+  headers.set("access-control-allow-origin", origin || "*")
+  headers.set("access-control-allow-methods", PROXY_ALLOWED_METHODS)
+  headers.set("access-control-allow-headers", allowedRequestedHeaders(request))
+  headers.set("access-control-max-age", "86400")
+
+  return headers
+}
+
+export function appendVaryHeader(headers, value) {
+  const existingValues = headers.get("vary")?.split(",").map((header) => header.trim()).filter(Boolean) || []
+  const nextValues = value.split(",").map((header) => header.trim()).filter(Boolean)
+
+  headers.set("vary", Array.from(new Set([...existingValues, ...nextValues])).join(", "))
+}

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -6,6 +6,7 @@ import {
   buildMediaMtxHlsUrl,
   normalizeMediaMtxApiBaseUrl,
 } from "../lib/mediamtx-url.mjs"
+import { corsHeaders } from "../lib/mediamtx-proxy-cors.mjs"
 
 assert.equal(normalizeMediaMtxApiBaseUrl(undefined), "/api/mediamtx")
 assert.equal(normalizeMediaMtxApiBaseUrl("http://localhost:9997/"), "http://localhost:9997")
@@ -24,7 +25,43 @@ assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://l
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const mediaMtxProxyRoute = fs.readFileSync("app/api/mediamtx/[...path]/route.ts", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+assert.ok(mediaMtxProxyRoute.includes("export const HEAD = proxyMediaMtxRequest"))
+assert.ok(mediaMtxProxyRoute.includes("export function OPTIONS"))
+
+const sameOriginPreflightHeaders = corsHeaders(
+  new Request("http://localhost:3000/api/mediamtx/v3/config/global/get", {
+    headers: {
+      origin: "http://localhost:3000",
+      "access-control-request-headers": "authorization, x-not-allowed, content-type",
+    },
+  }),
+)
+
+assert.equal(sameOriginPreflightHeaders.get("access-control-allow-origin"), "http://localhost:3000")
+assert.equal(sameOriginPreflightHeaders.get("access-control-allow-headers"), "authorization, content-type")
+assert.ok(sameOriginPreflightHeaders.get("access-control-allow-methods").includes("HEAD"))
+assert.ok(sameOriginPreflightHeaders.get("vary").includes("Origin"))
+
+const configuredOriginHeaders = corsHeaders(
+  new Request("http://localhost:3000/api/mediamtx/v3/config/global/get", {
+    headers: { origin: "https://dashboard.example.test" },
+  }),
+  "https://dashboard.example.test",
+)
+
+assert.equal(configuredOriginHeaders.get("access-control-allow-origin"), "https://dashboard.example.test")
+
+const rejectedOriginHeaders = corsHeaders(
+  new Request("http://localhost:3000/api/mediamtx/v3/config/global/get", {
+    headers: { origin: "https://evil.example.test" },
+  }),
+  "https://dashboard.example.test",
+)
+
+assert.equal(rejectedOriginHeaders.get("access-control-allow-origin"), null)
+assert.ok(rejectedOriginHeaders.get("vary").includes("Access-Control-Request-Headers"))


### PR DESCRIPTION
/claim #4

## Summary
- Add explicit OPTIONS handling for /api/mediamtx so browser Authorization preflights can complete before default MediaMTX login requests.
- Export HEAD through the same proxy path for lightweight health probes.
- Keep the proxy same-origin by default; cross-origin use requires an exact origin in MEDIAMTX_PROXY_ALLOWED_ORIGINS.
- Filter Access-Control-Request-Headers to the proxy allow-list instead of reflecting arbitrary headers.
- Preserve existing upstream Vary values when applying CORS headers.
- Document MEDIAMTX_PROXY_ALLOWED_ORIGINS in the Docker environment variable guide.
- Add behavioral regression assertions for allowed same-origin, configured cross-origin, rejected cross-origin, and filtered preflight headers.

## Why this helps the Docker/default-login bounty
The dashboard Docker flow commonly routes browser requests through the Next.js /api/mediamtx proxy. If that proxy is used from an allowed dashboard origin, the browser can send an Authorization preflight before the admin/adminpass login request reaches MediaMTX. Without an explicit OPTIONS handler, the login can fail before the credentials are even tested. HEAD also lets simple probes validate the proxy path without issuing a full GET.

## Security posture
This does not make the MediaMTX admin proxy open to every origin. Origins are allowed only when they are same-origin with the request URL or explicitly listed in MEDIAMTX_PROXY_ALLOWED_ORIGINS. Requested preflight headers are intersected with Accept, Authorization, and Content-Type.

## Validation
- Passed: bundled Node ran scripts/test-mediamtx-url.mjs
- Passed: git diff --check
- Not run: full Next build because this local environment does not have npm/pnpm or node_modules available without installing dependencies.

## Demo
Route-level behavior expected after this change:

```sh
curl -i -X OPTIONS "http://localhost:3000/api/mediamtx/v3/config/global/get" \
  -H "Origin: http://localhost:3000" \
  -H "Access-Control-Request-Method: GET" \
  -H "Access-Control-Request-Headers: authorization,content-type,x-not-allowed"
```

Expected response includes 204, access-control-allow-origin for the allowed origin, access-control-allow-methods including HEAD/OPTIONS, and access-control-allow-headers filtered to authorization/content-type.

AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.
