### PR TITLE
Harden default credential login fallback

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
 import { Radio, AlertCircle } from "lucide-react"
+import { buildLoginCredentialAttempts } from "@/lib/login-credentials.mjs"
 import { buildMediaMtxApiUrl } from "@/lib/mediamtx-url.mjs"
 
 export default function LoginPage() {
@@ -22,26 +23,34 @@ export default function LoginPage() {
     setIsLoading(true)
 
     try {
-      // Store credentials in sessionStorage
-      const credentials = btoa(`${username}:${password}`)
+      const attempts = buildLoginCredentialAttempts(username, password)
 
-      // Test the credentials by making a request to MediaMTX API
-      const response = await fetch(buildMediaMtxApiUrl("/v3/config/global/get"), {
-        headers: {
-          Authorization: `Basic ${credentials}`,
-        },
-      })
+      for (const attempt of attempts) {
+        const credentials = btoa(`${attempt.username}:${attempt.password}`)
 
-      if (response.ok) {
-        // Store credentials in sessionStorage
-        sessionStorage.setItem("mediamtx_auth", credentials)
-        sessionStorage.setItem("mediamtx_username", username)
+        // Test the credentials by making a request to MediaMTX API.
+        const response = await fetch(buildMediaMtxApiUrl("/v3/config/global/get"), {
+          headers: {
+            Authorization: `Basic ${credentials}`,
+          },
+        })
 
-        // Redirect to dashboard
-        router.push("/")
-      } else {
-        setError("Invalid username or password")
+        if (response.ok) {
+          // Store the exact credential variant that MediaMTX accepted.
+          sessionStorage.setItem("mediamtx_auth", credentials)
+          sessionStorage.setItem("mediamtx_username", attempt.username)
+
+          // Redirect to dashboard.
+          router.push("/")
+          return
+        }
+
+        if (response.status !== 401 && response.status !== 403) {
+          break
+        }
       }
+
+      setError("Invalid username or password")
     } catch (err) {
       setError("Failed to connect to MediaMTX server")
       console.error("Login error:", err)

--- a/lib/login-credentials.mjs
+++ b/lib/login-credentials.mjs
@@ -1,0 +1,11 @@
+export function buildLoginCredentialAttempts(username, password) {
+  const attempts = [{ username, password }]
+  const trimmedUsername = username.trim()
+  const trimmedPassword = password.trim()
+
+  if (trimmedUsername !== username || trimmedPassword !== password) {
+    attempts.push({ username: trimmedUsername, password: trimmedPassword })
+  }
+
+  return attempts
+}

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -6,6 +6,7 @@ import {
   buildMediaMtxHlsUrl,
   normalizeMediaMtxApiBaseUrl,
 } from "../lib/mediamtx-url.mjs"
+import { buildLoginCredentialAttempts } from "../lib/login-credentials.mjs"
 
 assert.equal(normalizeMediaMtxApiBaseUrl(undefined), "/api/mediamtx")
 assert.equal(normalizeMediaMtxApiBaseUrl("http://localhost:9997/"), "http://localhost:9997")
@@ -21,6 +22,12 @@ assert.equal(
   "http://localhost/v3/config/global/get",
 )
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
+
+assert.deepEqual(buildLoginCredentialAttempts("admin", "adminpass"), [{ username: "admin", password: "adminpass" }])
+assert.deepEqual(buildLoginCredentialAttempts(" admin ", "adminpass\n"), [
+  { username: " admin ", password: "adminpass\n" },
+  { username: "admin", password: "adminpass" },
+])
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")


### PR DESCRIPTION
This is a focused residual default-login hardening slice under the ongoing #4 bounty thread. It does not replace the broader Docker routing/proxy fixes; it covers copied whitespace around the advertised default credentials.

/claim #4

## Summary
- Try the submitted MediaMTX credentials exactly as typed first.
- If MediaMTX rejects them and trimming would change the username or password, retry once with leading/trailing whitespace removed.
- Store the credential variant that actually succeeds, and add a dependency-free regression assertion for the fallback behavior.

## Why
The dashboard advertises `admin` / `adminpass` as the default Docker credentials. If a user copies either value with a leading/trailing space or newline, the login request currently sends that whitespace verbatim and fails with the same symptom as “default credentials do not work.” The fallback only runs after a 401/403, so intentionally space-padded custom credentials still work when accepted by MediaMTX.

## Demo
- [Terminal proof clip](https://github.com/hubeiqiao/mediamtx-dashboard/releases/download/pr115-demo-20260520/mediamtx-pr115-terminal-demo.mov) showing the regression helper passing and the credential-attempt behavior for whitespace-copied default credentials.

## Verification
- `npm test`
- `./node_modules/.bin/tsc --noEmit`
- `npm run build`
- `git diff --check`

AI-assisted with OpenAI Codex; I reviewed the diff and validation locally before submitting.
