### PR TITLE
Encode HLS path segments

### DIFF
--- a/lib/mediamtx-url.mjs
+++ b/lib/mediamtx-url.mjs
@@ -21,8 +21,15 @@ export function normalizeMediaMtxHlsBaseUrl(hlsUrl = process.env.NEXT_PUBLIC_MED
   return trimTrailingSlashes((hlsUrl || DEFAULT_HLS_BASE_URL).trim())
 }
 
+function encodeHlsPathName(pathName) {
+  return pathName
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/")
+}
+
 export function buildMediaMtxHlsUrl(pathName, hlsUrl = process.env.NEXT_PUBLIC_MEDIAMTX_HLS_URL) {
   const normalizedPathName = pathName.replace(/^\/+/, "")
 
-  return `${normalizeMediaMtxHlsBaseUrl(hlsUrl)}/${normalizedPathName}/index.m3u8`
+  return `${normalizeMediaMtxHlsBaseUrl(hlsUrl)}/${encodeHlsPathName(normalizedPathName)}/index.m3u8`
 }

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -21,6 +21,14 @@ assert.equal(
   "http://localhost/v3/config/global/get",
 )
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
+assert.equal(
+  buildMediaMtxHlsUrl("front door", "http://localhost/hls/"),
+  "http://localhost/hls/front%20door/index.m3u8",
+)
+assert.equal(
+  buildMediaMtxHlsUrl("garage/camera#1?test", "http://localhost/hls/"),
+  "http://localhost/hls/garage/camera%231%3Ftest/index.m3u8",
+)
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")


### PR DESCRIPTION
## Summary

- Encode each MediaMTX HLS path segment when building playback manifest URLs
- Preserve nested MediaMTX path separators while escaping spaces and reserved URL characters
- Add regression coverage for paths with spaces, `#`, and `?`

## Why

After the default Docker/login flow succeeds, valid MediaMTX path names such as `front door` or `garage/camera#1?test` can still fail in the dashboard player because the raw path is appended directly into the HLS manifest URL. The browser treats reserved characters as URL syntax instead of path data.

This keeps the change scoped to the shared URL helper used by `StreamPlayer`.

## Verification

- `node scripts/test-mediamtx-url.mjs`
- `git diff --check`

`npm test` was not used directly on my Windows shell because PowerShell script execution policy blocks `npm.ps1`; the package script's underlying Node test file passed directly.

/claim #4