### PR TITLE
Fix MediaMTX list pagination

### DIFF
--- a/lib/mediamtx-api.ts
+++ b/lib/mediamtx-api.ts
@@ -1,5 +1,6 @@
 import { getAuthHeader } from "./auth"
 import { buildMediaMtxApiUrl } from "./mediamtx-url.mjs"
+import { buildMediaMtxListEndpoint, shouldFetchNextMediaMtxListPage } from "./mediamtx-pagination.mjs"
 
 export interface PathConfig {
   name: string
@@ -38,6 +39,12 @@ export interface Path {
   bytesReceived: number
   bytesSent: number
   readers: PathReader[]
+}
+
+interface MediaMtxListResponse<T> {
+  pageCount?: number
+  itemCount?: number
+  items?: T[]
 }
 
 async function fetchAPI(endpoint: string, options: RequestInit = {}) {
@@ -79,14 +86,32 @@ async function fetchAPI(endpoint: string, options: RequestInit = {}) {
   return text
 }
 
+async function fetchAllListItems<T>(endpoint: string): Promise<T[]> {
+  const items: T[] = []
+  let page = 0
+
+  while (true) {
+    const data = (await fetchAPI(buildMediaMtxListEndpoint(endpoint, page))) as MediaMtxListResponse<T> | null
+    const pageItems = data?.items
+
+    if (Array.isArray(pageItems)) {
+      items.push(...pageItems)
+    }
+
+    if (!shouldFetchNextMediaMtxListPage(data, page)) {
+      return items
+    }
+
+    page += 1
+  }
+}
+
 export async function getPathConfigs(): Promise<PathConfig[]> {
-  const data = await fetchAPI("/v3/config/paths/list")
-  return data.items || []
+  return fetchAllListItems<PathConfig>("/v3/config/paths/list")
 }
 
 export async function getPaths(): Promise<Path[]> {
-  const data = await fetchAPI("/v3/paths/list")
-  return data.items || []
+  return fetchAllListItems<Path>("/v3/paths/list")
 }
 
 export async function addPath(config: PathConfig): Promise<void> {
@@ -163,4 +188,3 @@ export async function deletePath(name: string): Promise<void> {
     method: "DELETE",
   })
 }
-

--- a/lib/mediamtx-pagination.mjs
+++ b/lib/mediamtx-pagination.mjs
@@ -1,0 +1,16 @@
+export const DEFAULT_MEDIAMTX_ITEMS_PER_PAGE = 100
+
+export function buildMediaMtxListEndpoint(endpoint, page, itemsPerPage = DEFAULT_MEDIAMTX_ITEMS_PER_PAGE) {
+  const normalizedEndpoint = endpoint.startsWith("/") ? endpoint : `/${endpoint}`
+  const separator = normalizedEndpoint.includes("?") ? "&" : "?"
+
+  return `${normalizedEndpoint}${separator}page=${page}&itemsPerPage=${itemsPerPage}`
+}
+
+export function shouldFetchNextMediaMtxListPage(response, page) {
+  if (!response || typeof response.pageCount !== "number" || !Number.isFinite(response.pageCount)) {
+    return false
+  }
+
+  return page + 1 < response.pageCount
+}

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -6,6 +6,7 @@ import {
   buildMediaMtxHlsUrl,
   normalizeMediaMtxApiBaseUrl,
 } from "../lib/mediamtx-url.mjs"
+import { buildMediaMtxListEndpoint, shouldFetchNextMediaMtxListPage } from "../lib/mediamtx-pagination.mjs"
 
 assert.equal(normalizeMediaMtxApiBaseUrl(undefined), "/api/mediamtx")
 assert.equal(normalizeMediaMtxApiBaseUrl("http://localhost:9997/"), "http://localhost:9997")
@@ -21,6 +22,16 @@ assert.equal(
   "http://localhost/v3/config/global/get",
 )
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
+
+assert.equal(buildMediaMtxListEndpoint("/v3/paths/list", 0), "/v3/paths/list?page=0&itemsPerPage=100")
+assert.equal(buildMediaMtxListEndpoint("v3/config/paths/list", 2), "/v3/config/paths/list?page=2&itemsPerPage=100")
+assert.equal(
+  buildMediaMtxListEndpoint("/v3/paths/list?query=cam", 1, 50),
+  "/v3/paths/list?query=cam&page=1&itemsPerPage=50",
+)
+assert.equal(shouldFetchNextMediaMtxListPage({ pageCount: 3 }, 0), true)
+assert.equal(shouldFetchNextMediaMtxListPage({ pageCount: 3 }, 2), false)
+assert.equal(shouldFetchNextMediaMtxListPage({ items: [] }, 0), false)
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")


### PR DESCRIPTION
Fix #21

/claim #21

## Summary
- Fetch every MediaMTX paginated list page for `/v3/paths/list` and `/v3/config/paths/list` instead of returning only the first page.
- Add a small pagination helper that builds `page` and `itemsPerPage` query parameters consistently.
- Add Node assertions for pagination endpoint generation and next-page detection.

## Why
MediaMTX list endpoints default to 100 items per page and return `pageCount`/`itemCount`. The dashboard previously returned only `data.items` from the first `/v3/paths/list` response, so deployments with more than one page showed only the first page of paths.

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npx tsc --noEmit`
- `npm run start -- -p 3300`, then `curl -I http://localhost:3300/`

## Demo notes
Record a short screen capture showing:
1. MediaMTX returning multiple `/v3/paths/list` pages.
2. The dashboard displaying paths from page 0 and later pages.
