### PR TITLE
Support UTF-8 MediaMTX login credentials

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
 import { Radio, AlertCircle } from "lucide-react"
+import { encodeBasicAuthCredentials } from "@/lib/basic-auth.mjs"
 import { buildMediaMtxApiUrl } from "@/lib/mediamtx-url.mjs"
 
 export default function LoginPage() {
@@ -22,8 +23,8 @@ export default function LoginPage() {
     setIsLoading(true)
 
     try {
-      // Store credentials in sessionStorage
-      const credentials = btoa(`${username}:${password}`)
+      // Encode credentials for the MediaMTX Basic auth request
+      const credentials = encodeBasicAuthCredentials(username, password)
 
       // Test the credentials by making a request to MediaMTX API
       const response = await fetch(buildMediaMtxApiUrl("/v3/config/global/get"), {

--- a/lib/basic-auth.mjs
+++ b/lib/basic-auth.mjs
@@ -1,0 +1,24 @@
+function bytesToBinary(bytes) {
+  const chunkSize = 0x8000
+  let binary = ""
+
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize))
+  }
+
+  return binary
+}
+
+export function encodeBasicAuthCredentials(username, password) {
+  const credentials = `${username}:${password}`
+
+  if (typeof TextEncoder !== "undefined" && typeof btoa === "function") {
+    return btoa(bytesToBinary(new TextEncoder().encode(credentials)))
+  }
+
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(credentials, "utf8").toString("base64")
+  }
+
+  throw new Error("No Base64 encoder is available")
+}

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import fs from "node:fs"
 
+import { encodeBasicAuthCredentials } from "../lib/basic-auth.mjs"
 import {
   buildMediaMtxApiUrl,
   buildMediaMtxHlsUrl,
@@ -21,6 +22,8 @@ assert.equal(
   "http://localhost/v3/config/global/get",
 )
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
+assert.equal(encodeBasicAuthCredentials("admin", "adminpass"), "YWRtaW46YWRtaW5wYXNz")
+assert.equal(encodeBasicAuthCredentials("admin", "pässwörd"), Buffer.from("admin:pässwörd", "utf8").toString("base64"))
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")


### PR DESCRIPTION
﻿/claim #4

## Summary
- Add a small shared Basic auth encoder that converts credentials to UTF-8 bytes before Base64 encoding.
- Use it in the login form instead of browser `btoa`.
- Keep the advertised default `admin` / `adminpass` token unchanged and add a UTF-8 password regression assertion.

## Why
The login form currently calls `btoa(`${username}:${password}`)`. Browser `btoa` only accepts Latin-1 input, so Docker users who override the bundled credentials with UTF-8 characters can fail in the browser before the request ever reaches MediaMTX. This keeps the default credential path intact while making customized Docker credentials reach the API correctly.

## Demo
- [Proof GIF](https://github.com/thefuturrjfhejh/mediamtx-dashboard/releases/download/pr4-utf8-basic-auth-demo/mediamtx-pr4-utf8-basic-auth-demo.gif)

## Verification
- `pnpm test`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `git diff --check`

Note: `pnpm build` compiled successfully and generated static pages, then failed during Next standalone traced-file copying on this Windows checkout with `EPERM: operation not permitted, symlink ...`; I did not count it as a passing build check.
