### PR TITLE
Show live paths created by all_others

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -44,6 +44,9 @@ import { clearAuth, getUsername } from "@/lib/auth"
 import { StreamPlayer } from "@/components/stream-player"
 import * as api from "@/lib/mediamtx-api"
 import type { PathConfig, Path as LivePath } from "@/lib/mediamtx-api"
+import { buildDashboardPathRows, summarizeDashboardPaths } from "@/lib/path-display.mjs"
+
+type DashboardPathRow = PathConfig & { runtimeOnly?: boolean }
 
 function MediaMTXDashboard() {
   const router = useRouter()
@@ -95,7 +98,7 @@ function MediaMTXDashboard() {
     setIsLoadingPaths(true)
     try {
       const [configs, live] = await Promise.all([api.getPathConfigs(), api.getPaths()])
-      setPaths(configs.filter((p) => p.name !== "all_others"))
+      setPaths(configs)
       setLivePaths(live)
     } catch (error) {
       console.error("Error fetching paths:", error)
@@ -168,6 +171,12 @@ function MediaMTXDashboard() {
     }
   }
 
+  const pathRows = buildDashboardPathRows(paths, livePaths) as DashboardPathRow[]
+  const { activeStreamsCount, idleConfiguredCount, totalDashboardPathCount } = summarizeDashboardPaths(
+    paths,
+    livePaths,
+  )
+
   const handleLogout = () => {
     clearAuth()
     router.push("/login")
@@ -215,8 +224,6 @@ function MediaMTXDashboard() {
     }
   }
 
-  // Replace the activeStreams useState with calculated values
-  const activeStreamsCount = livePaths.filter((p) => p.ready).length
   const totalViewers = livePaths.reduce((sum, p) => sum + p.readers.length, 0)
 
   return (
@@ -290,7 +297,7 @@ function MediaMTXDashboard() {
                 <CardContent>
                   <div className="text-2xl font-bold">{activeStreamsCount}</div>
                   <p className="text-xs text-muted-foreground">
-                    {activeStreamsCount} live, {paths.length - activeStreamsCount} idle
+                    {activeStreamsCount} live, {idleConfiguredCount} idle
                   </p>
                 </CardContent>
               </Card>
@@ -310,8 +317,8 @@ function MediaMTXDashboard() {
                   <Globe className="h-4 w-4 text-muted-foreground" />
                 </CardHeader>
                 <CardContent>
-                  <div className="text-2xl font-bold">{paths.length}</div>
-                  <p className="text-xs text-muted-foreground">Configured paths</p>
+                  <div className="text-2xl font-bold">{totalDashboardPathCount}</div>
+                  <p className="text-xs text-muted-foreground">Configured and live paths</p>
                 </CardContent>
               </Card>
               <Card>
@@ -337,7 +344,7 @@ function MediaMTXDashboard() {
                     <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 mb-2"></div>
                     <p className="text-sm text-gray-600">Loading streams...</p>
                   </div>
-                ) : paths.length === 0 ? (
+                ) : pathRows.length === 0 ? (
                   <div className="text-center py-8 text-gray-500">
                     <VideoIcon className="w-12 h-12 mx-auto mb-2 opacity-50" />
                     <p>No paths configured</p>
@@ -347,7 +354,7 @@ function MediaMTXDashboard() {
                   </div>
                 ) : (
                   <div className="space-y-4">
-                    {paths.map((path) => {
+                    {pathRows.map((path) => {
                       const status = getPathStatus(path.name)
                       return (
                         <div key={path.name} className="border rounded-lg overflow-hidden">
@@ -365,6 +372,7 @@ function MediaMTXDashboard() {
                                       LIVE
                                     </Badge>
                                   )}
+                                  {path.runtimeOnly && <Badge variant="outline">Runtime</Badge>}
                                 </div>
                                 <p className="text-sm text-gray-500">{path.source}</p>
                                 <div className="flex items-center gap-4 mt-1 text-xs text-gray-500">
@@ -388,12 +396,16 @@ function MediaMTXDashboard() {
                               >
                                 <Eye className="w-4 h-4" />
                               </Button>
-                              <Button size="sm" variant="outline" onClick={() => handleEditPath(path)}>
-                                <Edit className="w-4 h-4" />
-                              </Button>
-                              <Button size="sm" variant="outline" onClick={() => confirmDelete(path.name)}>
-                                <Trash2 className="w-4 h-4 text-red-600" />
-                              </Button>
+                              {!path.runtimeOnly && (
+                                <>
+                                  <Button size="sm" variant="outline" onClick={() => handleEditPath(path)}>
+                                    <Edit className="w-4 h-4" />
+                                  </Button>
+                                  <Button size="sm" variant="outline" onClick={() => confirmDelete(path.name)}>
+                                    <Trash2 className="w-4 h-4 text-red-600" />
+                                  </Button>
+                                </>
+                              )}
                             </div>
                           </div>
                           {selectedStreamPath === path.name && status.isLive && (
@@ -785,7 +797,7 @@ function MediaMTXDashboard() {
                       <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 mb-2"></div>
                       <p className="text-sm text-gray-600">Loading paths...</p>
                     </div>
-                  ) : paths.length === 0 ? (
+                  ) : pathRows.length === 0 ? (
                     <div className="text-center py-8 text-gray-500">
                       <VideoIcon className="w-12 h-12 mx-auto mb-2 opacity-50" />
                       <p>No paths configured</p>
@@ -794,7 +806,7 @@ function MediaMTXDashboard() {
                       </Button>
                     </div>
                   ) : (
-                    paths.map((path) => {
+                    pathRows.map((path) => {
                       const status = getPathStatus(path.name)
                       return (
                         <div key={path.name} className="border rounded-lg overflow-hidden">
@@ -812,6 +824,7 @@ function MediaMTXDashboard() {
                                       LIVE
                                     </Badge>
                                   )}
+                                  {path.runtimeOnly && <Badge variant="outline">Runtime</Badge>}
                                 </div>
                                 <p className="text-sm text-gray-500">{path.source}</p>
                                 <div className="flex items-center gap-4 mt-1 text-xs text-gray-500">
@@ -835,12 +848,16 @@ function MediaMTXDashboard() {
                               >
                                 <Eye className="w-4 h-4" />
                               </Button>
-                              <Button size="sm" variant="outline" onClick={() => handleEditPath(path)}>
-                                <Edit className="w-4 h-4" />
-                              </Button>
-                              <Button size="sm" variant="outline" onClick={() => confirmDelete(path.name)}>
-                                <Trash2 className="w-4 h-4 text-red-600" />
-                              </Button>
+                              {!path.runtimeOnly && (
+                                <>
+                                  <Button size="sm" variant="outline" onClick={() => handleEditPath(path)}>
+                                    <Edit className="w-4 h-4" />
+                                  </Button>
+                                  <Button size="sm" variant="outline" onClick={() => confirmDelete(path.name)}>
+                                    <Trash2 className="w-4 h-4 text-red-600" />
+                                  </Button>
+                                </>
+                              )}
                             </div>
                           </div>
                           {selectedStreamPath === path.name && status.isLive && (

--- a/lib/path-display.mjs
+++ b/lib/path-display.mjs
@@ -1,0 +1,56 @@
+export const ALL_OTHERS_PATH_NAME = "all_others"
+
+function pathName(path) {
+  return typeof path?.name === "string" ? path.name : ""
+}
+
+export function getConfiguredDashboardPaths(pathConfigs = []) {
+  return pathConfigs.filter((path) => pathName(path) && pathName(path) !== ALL_OTHERS_PATH_NAME)
+}
+
+function describeRuntimeSource(path) {
+  const sourceType = path?.source?.type
+
+  return sourceType ? `Live ${sourceType} source` : "Live published stream"
+}
+
+export function buildDashboardPathRows(pathConfigs = [], livePaths = []) {
+  const configuredPaths = getConfiguredDashboardPaths(pathConfigs).map((path) => ({
+    ...path,
+    runtimeOnly: false,
+  }))
+  const configuredNames = new Set(configuredPaths.map((path) => path.name))
+
+  const runtimeOnlyPaths = livePaths
+    .filter(
+      (path) =>
+        path?.ready && pathName(path) && !configuredNames.has(path.name) && path.name !== ALL_OTHERS_PATH_NAME,
+    )
+    .map((path) => ({
+      name: path.name,
+      source: describeRuntimeSource(path),
+      runtimeOnly: true,
+    }))
+
+  return [...configuredPaths, ...runtimeOnlyPaths]
+}
+
+export function summarizeDashboardPaths(pathConfigs = [], livePaths = []) {
+  const configuredPaths = getConfiguredDashboardPaths(pathConfigs)
+  const configuredNames = new Set(configuredPaths.map((path) => path.name))
+  const readyPathNames = new Set(
+    livePaths
+      .filter((path) => path?.ready && pathName(path) && path.name !== ALL_OTHERS_PATH_NAME)
+      .map((path) => path.name),
+  )
+  const runtimeOnlyCount = livePaths.filter(
+    (path) =>
+      path?.ready && pathName(path) && path.name !== ALL_OTHERS_PATH_NAME && !configuredNames.has(path.name),
+  ).length
+
+  return {
+    activeStreamsCount: readyPathNames.size,
+    idleConfiguredCount: configuredPaths.filter((path) => !readyPathNames.has(path.name)).length,
+    totalDashboardPathCount: configuredPaths.length + runtimeOnlyCount,
+  }
+}

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -6,6 +6,7 @@ import {
   buildMediaMtxHlsUrl,
   normalizeMediaMtxApiBaseUrl,
 } from "../lib/mediamtx-url.mjs"
+import { buildDashboardPathRows, summarizeDashboardPaths } from "../lib/path-display.mjs"
 
 assert.equal(normalizeMediaMtxApiBaseUrl(undefined), "/api/mediamtx")
 assert.equal(normalizeMediaMtxApiBaseUrl("http://localhost:9997/"), "http://localhost:9997")
@@ -28,3 +29,43 @@ const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+
+const defaultOnlyRows = buildDashboardPathRows(
+  [{ name: "all_others", source: "publisher" }],
+  [{ name: "camera/front", ready: true, source: { type: "rtsp" }, readers: [] }],
+)
+assert.deepEqual(defaultOnlyRows, [
+  {
+    name: "camera/front",
+    source: "Live rtsp source",
+    runtimeOnly: true,
+  },
+])
+
+assert.deepEqual(
+  summarizeDashboardPaths([{ name: "all_others", source: "publisher" }], [
+    { name: "camera/front", ready: true, readers: [] },
+  ]),
+  {
+    activeStreamsCount: 1,
+    idleConfiguredCount: 0,
+    totalDashboardPathCount: 1,
+  },
+)
+
+assert.deepEqual(
+  buildDashboardPathRows(
+    [
+      { name: "all_others", source: "publisher" },
+      { name: "camera/front", source: "publisher" },
+    ],
+    [{ name: "camera/front", ready: true, source: { type: "rtsp" }, readers: [] }],
+  ),
+  [
+    {
+      name: "camera/front",
+      source: "publisher",
+      runtimeOnly: false,
+    },
+  ],
+)


### PR DESCRIPTION
/claim #4

## Summary
- keep the raw MediaMTX path config list intact, but hide `all_others` only at display time
- add ready live paths without explicit configs as runtime-only dashboard rows
- keep edit/delete actions limited to configured paths, while allowing runtime rows to be viewed
- fix the overview counts so default publisher-created streams show as `1 live, 0 idle` instead of being hidden or producing a negative idle count
- add regression coverage for the default `all_others` + live `camera/front` case

## Demo
Short demo video with a mocked MediaMTX response containing only `all_others` in config and a live `camera/front` runtime path:

https://github.com/BeamoINT/mediamtx-dashboard/releases/download/runtime-live-paths-demo-20260520/mediamtx-runtime-live-paths-demo.mp4

Manual browser check: started the dashboard against the mock API, logged in with `admin` / `adminpass`, and confirmed the Overview shows `1 live, 0 idle`, `Total Paths 1`, plus a `camera/front` row marked `LIVE` and `Runtime`.

## Verification
- `npm test`
- `npm exec --yes pnpm@10 -- exec tsc --noEmit --pretty false`
- `npm run lint`
- `npm run build`
- `git diff --check`