### PR TITLE
Fix WebRTC additional host compose quoting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,9 +63,9 @@ services:
     volumes:
       - ./mediamtx.yml:/mediamtx.yml:ro
     environment:
-      - MTX_RTSPTRANSPORTS=tcp
-      - MTX_WEBRTCADDITIONALHOSTS="localhost"
-        #- MTX_PROTOCOLS_WEBRTC_ALLOWORIGIN=*
+      MTX_RTSPTRANSPORTS: tcp
+      MTX_WEBRTCADDITIONALHOSTS: localhost
+      # MTX_PROTOCOLS_WEBRTC_ALLOWORIGIN: "*"
     ports:
       - "9998:9998"
       - "9999:9999"

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -23,8 +23,11 @@ assert.equal(
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
+const defaultCompose = fs.readFileSync("docker-compose.yml", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
+assert.ok(!defaultCompose.includes('MTX_WEBRTCADDITIONALHOSTS="localhost"'))
+assert.ok(defaultCompose.includes("MTX_WEBRTCADDITIONALHOSTS: localhost"))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))


### PR DESCRIPTION
/claim #4

## Summary
- Switch the default compose publisher environment from list syntax to mapping syntax for `MTX_WEBRTCADDITIONALHOSTS`.
- Prevent Docker Compose from passing a literal quoted hostname into MediaMTX.
- Add a regression assertion to the existing dependency-free test script.

## Demo
https://github.com/iFaceTheWind/mediamtx-dashboard/releases/download/mediamtx-webrtc-compose-demo-20260520/mediamtx-webrtc-compose-demo.mp4

## Compose proof
Before, list syntax preserves embedded quotes as part of the environment value:

```yaml
environment:
  - FOO="bar"
```

```json
"environment": {
  "FOO": "\"bar\""
}
```

After, mapping syntax passes the intended hostname without literal quotes:

```yaml
environment:
  FOO: bar
```

```json
"environment": {
  "FOO": "bar"
}
```

## Verification
- `npm test` -> passed (`node scripts/test-mediamtx-url.mjs`)
- `git diff --check` -> passed

AI-assisted with OpenAI Codex; I reviewed the diff and local verification before submitting.
