### PR TITLE
Fix MediaMTX Docker env variable defaults

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -15,7 +15,7 @@ services:
       - ./mediamtx.yml:/mediamtx.yml
       - ./recordings:/recordings
     environment:
-      - MTX_PROTOCOLS=tcp
+      - MTX_RTSPTRANSPORTS=tcp
     networks:
       - mediamtx-network
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,7 +15,7 @@ services:
       - ./mediamtx.yml:/mediamtx.yml
       - recordings:/recordings
     environment:
-      - MTX_PROTOCOLS=tcp
+      - MTX_RTSPTRANSPORTS=tcp
     restart: always
     networks:
       - mediamtx-network

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -23,8 +23,13 @@ assert.equal(
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
+const localCompose = fs.readFileSync("docker-compose.local.yml", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
+assert.ok(!localCompose.includes("MTX_PROTOCOLS=tcp"))
+assert.ok(localCompose.includes("MTX_RTSPTRANSPORTS=tcp"))
+assert.ok(!prodCompose.includes("MTX_PROTOCOLS=tcp"))
+assert.ok(prodCompose.includes("MTX_RTSPTRANSPORTS=tcp"))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))


### PR DESCRIPTION
Related to #4

/claim #4

## Summary
- Replace the obsolete `MTX_PROTOCOLS=tcp` entries in the local and production compose files with `MTX_RTSPTRANSPORTS=tcp`, matching the `rtspTransports` key used by the bundled MediaMTX config and the default compose path.
- Add regression assertions to the existing dependency-free test script so the local and production Docker env defaults do not drift back.

## Short demo / reviewer proof
Before this PR, the local and production compose paths contained the old env key:

```yaml
- MTX_PROTOCOLS=tcp
```

After this PR, both files use the MediaMTX env key that matches the repo config and default compose path:

```yaml
- MTX_RTSPTRANSPORTS=tcp
```

The regression test now proves the same behavior without needing a live Docker daemon:

```js
assert.ok(!localCompose.includes("MTX_PROTOCOLS=tcp"))
assert.ok(localCompose.includes("MTX_RTSPTRANSPORTS=tcp"))
assert.ok(!prodCompose.includes("MTX_PROTOCOLS=tcp"))
assert.ok(prodCompose.includes("MTX_RTSPTRANSPORTS=tcp"))
```

Running `npm test` executes those assertions through `scripts/test-mediamtx-url.mjs`.

## Why
The default Docker login path depends on MediaMTX starting with the bundled config before the dashboard can validate `admin` / `adminpass`. The default compose file already uses `MTX_RTSPTRANSPORTS=tcp`, but the local and production compose paths still used `MTX_PROTOCOLS=tcp`, which does not match the repo config key. Aligning those compose files keeps all Docker paths on the same MediaMTX env surface before login.

## Validation
- `npm test`
- `node --check scripts/test-mediamtx-url.mjs`
- `git diff --check`
- `ruby -e 'require "yaml"; %w[docker-compose.local.yml docker-compose.prod.yml].each { |f| YAML.load_file(f); puts "#{f} ok" }'`

I could not run a live Docker smoke test in this environment because Docker is not installed here. This is a compose/config-only patch; no live MediaMTX instance or private data was accessed. AI-assisted with OpenAI Codex; I reviewed the diff and validation before submitting.
