### PR TITLE
Classify MediaMTX login API errors

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
 import { Radio, AlertCircle } from "lucide-react"
+import { loginErrorMessageForResponse } from "@/lib/mediamtx-login.mjs"
 import { buildMediaMtxApiUrl } from "@/lib/mediamtx-url.mjs"
 
 export default function LoginPage() {
@@ -40,10 +41,11 @@ export default function LoginPage() {
         // Redirect to dashboard
         router.push("/")
       } else {
-        setError("Invalid username or password")
+        const responseText = await response.text().catch(() => "")
+        setError(loginErrorMessageForResponse(response.status, response.statusText, responseText))
       }
     } catch (err) {
-      setError("Failed to connect to MediaMTX server")
+      setError(loginErrorMessageForResponse(0, "", err instanceof Error ? err.message : ""))
       console.error("Login error:", err)
     } finally {
       setIsLoading(false)

--- a/lib/mediamtx-login.mjs
+++ b/lib/mediamtx-login.mjs
@@ -1,0 +1,47 @@
+export function loginErrorMessageForResponse(status, statusText = "", responseText = "") {
+  if (status === 401 || status === 403) {
+    return "Invalid username or password"
+  }
+
+  const upstreamMessage = parseUpstreamErrorMessage(responseText)
+  if (upstreamMessage) {
+    return upstreamMessage
+  }
+
+  if (status === 404) {
+    return "MediaMTX API endpoint was not found. Check the dashboard proxy and API URL configuration."
+  }
+
+  if (status === 502 || status === 503 || status === 504) {
+    return "MediaMTX API is unavailable. Wait for Docker services to finish starting, then try again."
+  }
+
+  if (status >= 500) {
+    return "MediaMTX API returned a server error. Check the dashboard and MediaMTX container logs."
+  }
+
+  if (status > 0) {
+    const suffix = statusText ? ` ${statusText}` : ""
+    return `MediaMTX login check failed with HTTP ${status}${suffix}`
+  }
+
+  return "Failed to connect to MediaMTX server"
+}
+
+function parseUpstreamErrorMessage(responseText) {
+  if (!responseText || typeof responseText !== "string") {
+    return null
+  }
+
+  try {
+    const payload = JSON.parse(responseText)
+
+    if (payload && typeof payload === "object" && typeof payload.message === "string") {
+      return payload.message
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import fs from "node:fs"
 
+import { loginErrorMessageForResponse } from "../lib/mediamtx-login.mjs"
 import {
   buildMediaMtxApiUrl,
   buildMediaMtxHlsUrl,
@@ -21,6 +22,25 @@ assert.equal(
   "http://localhost/v3/config/global/get",
 )
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
+
+assert.equal(loginErrorMessageForResponse(401), "Invalid username or password")
+assert.equal(loginErrorMessageForResponse(403), "Invalid username or password")
+assert.equal(
+  loginErrorMessageForResponse(502),
+  "MediaMTX API is unavailable. Wait for Docker services to finish starting, then try again.",
+)
+assert.equal(
+  loginErrorMessageForResponse(504),
+  "MediaMTX API is unavailable. Wait for Docker services to finish starting, then try again.",
+)
+assert.equal(
+  loginErrorMessageForResponse(
+    502,
+    "Bad Gateway",
+    JSON.stringify({ message: "The dashboard could not reach the MediaMTX API upstream." }),
+  ),
+  "The dashboard could not reach the MediaMTX API upstream.",
+)
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")


### PR DESCRIPTION
/claim #4

Summary:
- Keep 401/403 login responses mapped to invalid credentials.
- Parse MediaMTX proxy/API JSON error responses and show the upstream message on the login page.
- Show actionable messages for missing API routes, unavailable Docker/API upstreams, server errors, and connection failures.
- Cover the login error mapping in the existing Node smoke test.

Demo video:
https://github.com/Cosmic-Game-studios/mediamtx-dashboard/releases/download/mediamtx-login-error-demo-d25c7c5/mediamtx-login-error-demo.webm

Validation:
- npm test
- git diff --check HEAD~1 HEAD
- .\\node_modules\\.bin\\next.cmd lint
- .\\node_modules\\.bin\\next.cmd build (compiled successfully; Windows emitted a post-build standalone symlink warning)
