### PR TITLE
Harden Docker troubleshooting checks

### DIFF
--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -24,7 +24,13 @@ assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://l
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const troubleshoot = fs.readFileSync("scripts/troubleshoot.sh", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+
+assert.ok(troubleshoot.includes("COMPOSE_CMD=(docker compose)"))
+assert.ok(troubleshoot.includes('curl -sS -o /dev/null -w "%{http_code}"'))
+assert.ok(troubleshoot.includes('MEDIAMTX_PASSWORD:-adminpass'))
+assert.ok(troubleshoot.includes("MediaMTX API rejected credentials"))

--- a/scripts/troubleshoot.sh
+++ b/scripts/troubleshoot.sh
@@ -4,6 +4,12 @@ echo "🔍 MediaMTX Docker Troubleshooting"
 echo "=================================="
 echo ""
 
+COMPOSE_CMD=()
+
+format_compose_cmd() {
+    printf "%s" "${COMPOSE_CMD[*]}"
+}
+
 # Check Docker
 echo "1. Checking Docker installation..."
 if command -v docker &> /dev/null; then
@@ -17,9 +23,14 @@ fi
 echo ""
 echo "2. Checking Docker Compose..."
 if command -v docker-compose &> /dev/null; then
+    COMPOSE_CMD=(docker-compose)
     echo "   ✅ Docker Compose is installed: $(docker-compose --version)"
+elif docker compose version &> /dev/null; then
+    COMPOSE_CMD=(docker compose)
+    echo "   ✅ Docker Compose is installed: $(docker compose version)"
 else
     echo "   ❌ Docker Compose is not installed"
+    echo "   Install Docker Compose v2 or legacy docker-compose, then re-run this script"
     exit 1
 fi
 
@@ -30,7 +41,7 @@ if ping -c 1 dl-cdn.alpinelinux.org &> /dev/null; then
     echo "   ✅ Can reach Alpine package servers"
 else
     echo "   ⚠️  Cannot reach Alpine servers (will use Debian image)"
-    echo "   Run: docker-compose build --build-arg DOCKERFILE=Dockerfile.debian"
+    echo "   Run: $(format_compose_cmd) build --build-arg DOCKERFILE=Dockerfile.debian"
 fi
 
 # Check ports
@@ -45,15 +56,45 @@ for port in "${ports[@]}"; do
     fi
 done
 
+# Check authenticated MediaMTX API path when the stack is already running
+echo ""
+echo "5. Checking MediaMTX API with configured credentials..."
+if ! command -v curl &> /dev/null; then
+    echo "   ⚠️  curl is not installed; skipping API credential check"
+else
+    api_port="${API_PORT:-9997}"
+    mediamtx_username="${MEDIAMTX_USERNAME:-admin}"
+    mediamtx_password="${MEDIAMTX_PASSWORD:-adminpass}"
+    api_url="http://localhost:${api_port}/v3/config/global/get"
+    http_status=$(curl -sS -o /dev/null -w "%{http_code}" -u "${mediamtx_username}:${mediamtx_password}" "$api_url" 2>/dev/null || true)
+
+    case "$http_status" in
+        200)
+            echo "   ✅ MediaMTX API accepts credentials for user '${mediamtx_username}'"
+            ;;
+        000)
+            echo "   ⚠️  MediaMTX API is not reachable at $api_url"
+            echo "   Start the stack with: $(format_compose_cmd) up -d"
+            ;;
+        401|403)
+            echo "   ❌ MediaMTX API rejected credentials for user '${mediamtx_username}'"
+            echo "   Check MEDIAMTX_USERNAME/MEDIAMTX_PASSWORD and the login form defaults"
+            ;;
+        *)
+            echo "   ⚠️  MediaMTX API returned HTTP $http_status at $api_url"
+            ;;
+    esac
+fi
+
 # Check disk space
 echo ""
-echo "5. Checking disk space..."
+echo "6. Checking disk space..."
 available=$(df -h . | awk 'NR==2 {print $4}')
 echo "   Available space: $available"
 
 # Try building
 echo ""
-echo "6. Attempting to build..."
+echo "7. Attempting to build..."
 echo "   Testing Alpine build..."
 if docker build -f Dockerfile -t mediamtx-test:alpine . &> /dev/null; then
     echo "   ✅ Alpine build successful"


### PR DESCRIPTION
/claim #4

## Proposed Changes

- Detect Docker Compose v2 (`docker compose`) as a valid fallback when the legacy `docker-compose` binary is unavailable.
- Use the detected Compose command in troubleshooting recommendations.
- Add a non-destructive MediaMTX API credential diagnostic using `MEDIAMTX_USERNAME`, `MEDIAMTX_PASSWORD`, and `API_PORT` defaults.
- Extend the existing smoke test to cover the new troubleshooting checks.

## Proof

- `npm test`
- `bash -n scripts/troubleshoot.sh`
- `git diff --check`
- Simulated Compose v2-only troubleshooting run with stubbed Docker/curl commands verified the script reports `docker compose`, checks the API auth path, and exits successfully.

## Checklist

- [x] PR created against `main`
- [x] Tests/checks passed locally
- [x] Focused change only; no Docker containers are started or stopped by the new diagnostic
