### PR TITLE
Avoid JSON content type on bodyless API requests

### DIFF
--- a/lib/mediamtx-api.ts
+++ b/lib/mediamtx-api.ts
@@ -1,4 +1,5 @@
 import { getAuthHeader } from "./auth"
+import { buildMediaMtxRequestHeaders } from "./mediamtx-request-headers.mjs"
 import { buildMediaMtxApiUrl } from "./mediamtx-url.mjs"
 
 export interface PathConfig {
@@ -42,14 +43,11 @@ export interface Path {
 
 async function fetchAPI(endpoint: string, options: RequestInit = {}) {
   const authHeader = getAuthHeader()
+  const headers = buildMediaMtxRequestHeaders(authHeader, options.headers, options.body !== undefined)
 
   const response = await fetch(buildMediaMtxApiUrl(endpoint), {
     ...options,
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: authHeader,
-      ...options.headers,
-    },
+    headers,
   })
 
   const contentType = response.headers.get("content-type") || ""
@@ -163,4 +161,3 @@ export async function deletePath(name: string): Promise<void> {
     method: "DELETE",
   })
 }
-

--- a/lib/mediamtx-request-headers.mjs
+++ b/lib/mediamtx-request-headers.mjs
@@ -1,0 +1,13 @@
+export function buildMediaMtxRequestHeaders(authHeader, optionsHeaders, hasBody) {
+  const headers = new Headers(optionsHeaders)
+
+  if (authHeader) {
+    headers.set("Authorization", authHeader)
+  }
+
+  if (hasBody && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json")
+  }
+
+  return headers
+}

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import fs from "node:fs"
 
+import { buildMediaMtxRequestHeaders } from "../lib/mediamtx-request-headers.mjs"
 import {
   buildMediaMtxApiUrl,
   buildMediaMtxHlsUrl,
@@ -21,6 +22,24 @@ assert.equal(
   "http://localhost/v3/config/global/get",
 )
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
+
+{
+  const headers = buildMediaMtxRequestHeaders("Basic token", undefined, false)
+  assert.equal(headers.get("Authorization"), "Basic token")
+  assert.equal(headers.has("Content-Type"), false)
+}
+
+{
+  const headers = buildMediaMtxRequestHeaders("Basic token", undefined, true)
+  assert.equal(headers.get("Authorization"), "Basic token")
+  assert.equal(headers.get("Content-Type"), "application/json")
+}
+
+{
+  const headers = buildMediaMtxRequestHeaders("Basic token", { "Content-Type": "text/plain" }, true)
+  assert.equal(headers.get("Authorization"), "Basic token")
+  assert.equal(headers.get("Content-Type"), "text/plain")
+}
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")


### PR DESCRIPTION
## Summary
- add a shared MediaMTX request-header helper
- keep the Basic auth header on every dashboard API call
- only add `Content-Type: application/json` when the request has a body, preserving explicit caller headers

## Why
For direct cross-origin MediaMTX API deployments, adding `Content-Type: application/json` to bodyless `GET` requests can force an unnecessary browser preflight before the default credential request path reaches MediaMTX. This keeps the default same-origin proxy behavior unchanged while reducing a direct-API failure mode.

## Validation
- `NEXT_PUBLIC_MEDIAMTX_API_URL='' NEXT_PUBLIC_MEDIAMTX_HLS_URL='' bun run test`
- `bunx tsc --noEmit`
- `bun run lint`
- `git diff --check`

This is a non-visual request-header change, so I included regression coverage instead of a UI demo video.

/claim #4