### PR TITLE
Redirect stale MediaMTX auth to login

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -91,6 +91,14 @@ function MediaMTXDashboard() {
   })
   const [isSubmitting, setIsSubmitting] = useState(false)
 
+  const handleAuthError = (error: unknown) => {
+    if (!api.isMediaMtxAuthError(error)) return false
+
+    clearAuth()
+    router.push("/login")
+    return true
+  }
+
   const fetchPaths = async () => {
     setIsLoadingPaths(true)
     try {
@@ -98,6 +106,7 @@ function MediaMTXDashboard() {
       setPaths(configs.filter((p) => p.name !== "all_others"))
       setLivePaths(live)
     } catch (error) {
+      if (handleAuthError(error)) return
       console.error("Error fetching paths:", error)
       alert("Failed to load paths")
     } finally {
@@ -127,6 +136,7 @@ function MediaMTXDashboard() {
       setEditingPath(null)
       alert("Path updated successfully!")
     } catch (error) {
+      if (handleAuthError(error)) return
       console.error("Error updating path:", error)
       alert(`Failed to update path: ${error instanceof Error ? error.message : "Unknown error"}`)
     } finally {
@@ -145,6 +155,7 @@ function MediaMTXDashboard() {
       setPathToDelete(null)
       alert("Path deleted successfully!")
     } catch (error) {
+      if (handleAuthError(error)) return
       console.error("Error deleting path:", error)
       alert(`Failed to delete path: ${error instanceof Error ? error.message : "Unknown error"}`)
     } finally {
@@ -208,6 +219,7 @@ function MediaMTXDashboard() {
       setIsAddPathDialogOpen(false)
       alert("Path added successfully!")
     } catch (error) {
+      if (handleAuthError(error)) return
       console.error("Error adding path:", error)
       alert(`Error adding path: ${error instanceof Error ? error.message : "Unknown error"}`)
     } finally {

--- a/lib/mediamtx-api.ts
+++ b/lib/mediamtx-api.ts
@@ -1,5 +1,8 @@
 import { getAuthHeader } from "./auth"
+import { MediaMtxApiError, isMediaMtxAuthError } from "./mediamtx-errors.mjs"
 import { buildMediaMtxApiUrl } from "./mediamtx-url.mjs"
+
+export { isMediaMtxAuthError }
 
 export interface PathConfig {
   name: string
@@ -59,7 +62,12 @@ async function fetchAPI(endpoint: string, options: RequestInit = {}) {
     try {
       errorText = await response.text()
     } catch {}
-    throw new Error(errorText || `API request failed: ${response.status} ${response.statusText}`)
+    throw new MediaMtxApiError(
+      errorText || `API request failed: ${response.status} ${response.statusText}`,
+      response.status,
+      response.statusText,
+      errorText,
+    )
   }
 
   if (response.status === 204) return null

--- a/lib/mediamtx-errors.mjs
+++ b/lib/mediamtx-errors.mjs
@@ -1,0 +1,13 @@
+export class MediaMtxApiError extends Error {
+  constructor(message, status, statusText = "", body = "") {
+    super(message)
+    this.name = "MediaMtxApiError"
+    this.status = status
+    this.statusText = statusText
+    this.body = body
+  }
+}
+
+export function isMediaMtxAuthError(error) {
+  return error instanceof MediaMtxApiError && (error.status === 401 || error.status === 403)
+}

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import fs from "node:fs"
 
+import { MediaMtxApiError, isMediaMtxAuthError } from "../lib/mediamtx-errors.mjs"
 import {
   buildMediaMtxApiUrl,
   buildMediaMtxHlsUrl,
@@ -21,6 +22,11 @@ assert.equal(
   "http://localhost/v3/config/global/get",
 )
 assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://localhost/hls/mystream/index.m3u8")
+
+assert.equal(isMediaMtxAuthError(new MediaMtxApiError("Unauthorized", 401)), true)
+assert.equal(isMediaMtxAuthError(new MediaMtxApiError("Forbidden", 403)), true)
+assert.equal(isMediaMtxAuthError(new MediaMtxApiError("Server error", 500)), false)
+assert.equal(isMediaMtxAuthError(new Error("Unauthorized")), false)
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")


### PR DESCRIPTION
/claim #4

## Summary

- Add a small MediaMTX API error type that preserves HTTP status codes.
- Treat post-login `401` and `403` API responses as stale dashboard auth.
- Clear the stored dashboard session token and send the user back to `/login` instead of leaving the dashboard polling with repeated API errors.
- Add focused regression coverage for the auth-error classifier.

## Why

The dashboard currently considers a user authenticated as soon as `sessionStorage` contains `mediamtx_auth`. If that token later becomes invalid, expires, or no longer matches the MediaMTX config, the protected dashboard still renders and continues calling MediaMTX endpoints. Those calls can return `401` or `403`, but the user is not sent back through the login flow.

This keeps non-auth API errors unchanged while making stale credentials recoverable: the next protected API call clears the stale session and redirects to login.

## Validation

- `npm test`
- `git diff --check`
- `pnpm exec tsc --noEmit` passed before generated dependency cleanup
- `pnpm run lint` passed before generated dependency cleanup, with the existing `fetchPaths` hook-dependency warning
- `pnpm run build` compiled successfully before failing during local Windows Next standalone symlink copying (`EPERM`)