### PR TITLE
Harden auth UI and E2E proxy smoke check

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -35,7 +36,7 @@ jobs:
         run: |
           pnpm start &  # runs on port 3000 by default
           sleep 10
-          curl -f http://localhost:3000/api/streams || exit 1
+          curl -f http://localhost:3000/api/mediamtx/v3/config/global/get || exit 1
 
       - name: Logs on failure
         if: failure()

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -932,7 +932,7 @@ function MediaMTXDashboard() {
                       </div>
                       <div className="space-y-2">
                         <Label>Password</Label>
-                        <Input type="password" value="adminpass" readOnly />
+                        <Input type="password" placeholder="Configured in MediaMTX" readOnly />
                       </div>
                     </div>
                     <div className="mt-4">

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -24,7 +24,13 @@ assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://l
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const dashboardPage = fs.readFileSync("app/page.tsx", "utf8")
+const e2eWorkflow = fs.readFileSync(".github/workflows/e2e-test.yml", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+assert.ok(!dashboardPage.includes('value="adminpass"'))
+assert.ok(e2eWorkflow.includes("pnpm/action-setup@v3"))
+assert.ok(!e2eWorkflow.includes("/api/streams"))
+assert.ok(e2eWorkflow.includes("/api/mediamtx/v3/config/global/get"))


### PR DESCRIPTION
## Summary
- stop rendering the default administrator password literal in the Auth tab
- make the E2E workflow install pnpm before using pnpm commands
- update the E2E smoke check to hit the real MediaMTX proxy route instead of missing `/api/streams`
- add regression assertions to the existing smoke test for these cases

## Proof
- `corepack pnpm test`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`
- `git diff --check`

/claim #4