### PR TITLE
Clean up native HLS stream listeners

### DIFF
--- a/components/stream-player.tsx
+++ b/components/stream-player.tsx
@@ -19,18 +19,33 @@ export function StreamPlayer({ pathName }: StreamPlayerProps) {
     if (!video) return
 
     const hlsUrl = buildMediaMtxHlsUrl(pathName)
+    let disposed = false
 
     setIsLoading(true)
     setError(null)
 
     // Check if HLS is natively supported (Safari)
     if (video.canPlayType("application/vnd.apple.mpegurl")) {
-      video.src = hlsUrl
-      video.addEventListener("loadedmetadata", () => setIsLoading(false))
-      video.addEventListener("error", () => {
+      const handleLoadedMetadata = () => {
+        if (!disposed) setIsLoading(false)
+      }
+      const handleNativeError = () => {
+        if (disposed) return
         setError("Failed to load stream")
         setIsLoading(false)
-      })
+      }
+
+      video.src = hlsUrl
+      video.addEventListener("loadedmetadata", handleLoadedMetadata)
+      video.addEventListener("error", handleNativeError)
+
+      return () => {
+        disposed = true
+        video.removeEventListener("loadedmetadata", handleLoadedMetadata)
+        video.removeEventListener("error", handleNativeError)
+        video.removeAttribute("src")
+        video.load()
+      }
     } else if (Hls.isSupported()) {
       // Use HLS.js for browsers that don't support HLS natively
       const hls = new Hls({
@@ -44,6 +59,7 @@ export function StreamPlayer({ pathName }: StreamPlayerProps) {
       hls.attachMedia(video)
 
       hls.on(Hls.Events.MANIFEST_PARSED, () => {
+        if (disposed) return
         setIsLoading(false)
         video.play().catch((err) => {
           console.warn("Autoplay prevented:", err)
@@ -51,6 +67,7 @@ export function StreamPlayer({ pathName }: StreamPlayerProps) {
       })
 
       hls.on(Hls.Events.ERROR, (event, data) => {
+        if (disposed) return
         console.error("HLS error:", data)
         if (data.fatal) {
           setError(`Streaming error: ${data.type}`)
@@ -63,6 +80,7 @@ export function StreamPlayer({ pathName }: StreamPlayerProps) {
     }
 
     return () => {
+      disposed = true
       if (hlsRef.current) {
         hlsRef.current.destroy()
         hlsRef.current = null

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -24,7 +24,12 @@ assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://l
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const streamPlayer = fs.readFileSync("components/stream-player.tsx", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+assert.ok(streamPlayer.includes('removeEventListener("loadedmetadata"'))
+assert.ok(streamPlayer.includes('removeEventListener("error"'))
+assert.ok(streamPlayer.includes('removeAttribute("src")'))
+assert.ok(streamPlayer.includes("video.load()"))


### PR DESCRIPTION
/claim #4

## Summary
- Clean up Safari/native HLS `loadedmetadata` and `error` listeners when `StreamPlayer` unmounts or switches paths.
- Clear the native video `src` and reload the element so the previous stream does not continue holding state.
- Guard late HLS.js callbacks after cleanup.
- Add dependency-free regression assertions to the existing smoke test.

## Why
After the default Docker/login flow succeeds, Safari can use native HLS instead of HLS.js. The native branch was adding anonymous event listeners without removing them, so toggling stream previews or switching path names could leave old handlers and media state attached to the `<video>` element. This keeps the playback cleanup path aligned with the HLS.js destroy path.

## Verification
- `corepack pnpm test`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`
- `git diff --check`

Note: `next build` completed successfully and emitted the existing workspace-root warning because a parent `/Users/tulisy/package-lock.json` is visible alongside this repo's `pnpm-lock.yaml`.

AI-assisted with OpenAI Codex; I reviewed the diff and validation locally before submitting.