### PR TITLE
Keep Docker setup on pnpm lockfile

### DIFF
--- a/scripts/setup-docker.sh
+++ b/scripts/setup-docker.sh
@@ -1,16 +1,8 @@
 #!/bin/bash
+set -euo pipefail
 
-echo "🔧 Setting up Docker build environment..."
+echo "🔧 Setting up Docker build environment with pnpm..."
 echo ""
-
-# Check if package-lock.json exists
-if [ ! -f "package-lock.json" ]; then
-    echo "📦 package-lock.json not found, generating..."
-    npm install --package-lock-only
-    echo "✅ package-lock.json created"
-else
-    echo "✅ package-lock.json exists"
-fi
 
 # Verify package.json
 if [ -f "package.json" ]; then
@@ -20,10 +12,32 @@ else
     exit 1
 fi
 
-# Clean npm cache
+# Ensure pnpm is available for lockfile maintenance
+if ! command -v pnpm >/dev/null 2>&1; then
+    echo "📦 pnpm not found, enabling with corepack..."
+    if command -v corepack >/dev/null 2>&1; then
+        corepack enable
+    fi
+fi
+
+if ! command -v pnpm >/dev/null 2>&1; then
+    echo "📦 corepack did not provide pnpm, installing pnpm globally..."
+    npm install -g pnpm
+fi
+
+# Check if pnpm-lock.yaml exists
+if [ ! -f "pnpm-lock.yaml" ]; then
+    echo "📦 pnpm-lock.yaml not found, generating..."
+    pnpm install --lockfile-only
+    echo "✅ pnpm-lock.yaml created"
+else
+    echo "✅ pnpm-lock.yaml exists"
+fi
+
+# Clean pnpm store metadata when available
 echo ""
-echo "🧹 Cleaning npm cache..."
-npm cache clean --force
+echo "🧹 Pruning pnpm store..."
+pnpm store prune || true
 
 # Remove node_modules if exists
 if [ -d "node_modules" ]; then

--- a/scripts/test-mediamtx-url.mjs
+++ b/scripts/test-mediamtx-url.mjs
@@ -24,7 +24,13 @@ assert.equal(buildMediaMtxHlsUrl("mystream", "http://localhost/hls/"), "http://l
 
 const dockerfile = fs.readFileSync("Dockerfile", "utf8")
 const prodCompose = fs.readFileSync("docker-compose.prod.yml", "utf8")
+const setupDocker = fs.readFileSync("scripts/setup-docker.sh", "utf8")
 
 assert.ok(!dockerfile.includes('NEXT_PUBLIC_MEDIAMTX_API_URL="http://localhost:80/v3/config"'))
 assert.ok(!prodCompose.includes("NEXT_PUBLIC_MEDIAMTX_API_URL=http://mediamtx:9997"))
 assert.ok(prodCompose.includes("MEDIAMTX_API_URL=http://mediamtx:9997"))
+assert.ok(!setupDocker.includes("package-lock.json"))
+assert.ok(!setupDocker.includes("npm install --package-lock-only"))
+assert.ok(!setupDocker.includes("npm cache clean"))
+assert.ok(setupDocker.includes("pnpm-lock.yaml"))
+assert.ok(setupDocker.includes("pnpm install --lockfile-only"))


### PR DESCRIPTION
/claim #4

## Summary
- update `scripts/setup-docker.sh` to use `pnpm-lock.yaml` instead of generating `package-lock.json`
- ensure `pnpm` is available before lockfile maintenance and prune the pnpm store instead of the npm cache
- add regression coverage so the Docker setup helper does not drift back to npm lockfile generation

## Why
The Docker setup path is part of the fresh-checkout Docker workflow users hit before testing the default credentials. The app is committed with `pnpm-lock.yaml`, and the Dockerfiles use pnpm, but the helper still generated a local npm lockfile and cleaned npm cache state. That can leave the setup path in the wrong package-manager mode before the MediaMTX/default-login flow is ever exercised.

## Validation
- `npm test`
- `bash -n scripts/setup-docker.sh`
- `git diff --check`